### PR TITLE
fix(docker): add Node.js and npm install for JS dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,12 @@ FROM ${BUILDER_IMAGE} AS builder
 
 # install build dependencies
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential git \
+  && apt-get install -y --no-install-recommends build-essential git curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# install nodejs for npm dependencies
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+  && apt-get install -y nodejs \
   && rm -rf /var/lib/apt/lists/*
 
 # prepare build dir
@@ -56,6 +61,9 @@ COPY lib lib
 RUN mix compile
 
 COPY assets assets
+
+# install npm dependencies
+RUN npm ci --prefix assets
 
 # compile assets
 RUN mix assets.deploy


### PR DESCRIPTION
## Summary

- Fix Docker build by installing Node.js and running npm install for JS dependencies

## Problem

The Docker build was failing at the `mix assets.deploy` step because npm dependencies (`@milkdown/kit`, `@milkdown/plugin-highlight`, `lowlight`, `highlight.js`) from `assets/package.json` were never installed.

## Solution

- Added `curl` to build dependencies
- Added Node.js 22.x installation in builder stage
- Added `npm ci --prefix assets` step after copying assets directory

## Test plan

- [x] Verified Docker build completes successfully
- [x] Verified release is created at `_build/prod/rel/citadel`
- [x] Image size is ~475MB (85MB compressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)