### PR TITLE
feat: expose TaskDependency via MCP tools

### DIFF
--- a/lib/citadel/tasks.ex
+++ b/lib/citadel/tasks.ex
@@ -13,7 +13,7 @@ defmodule Citadel.Tasks do
     end
 
     tool :create_task, Citadel.Tasks.Task, :create do
-      description "Creates a new task with a title, optional markdown description, and task state. To create a sub-task, provide a parent_task_id. Can also set assignees (array of user IDs), due_date, and priority (low, medium, high, urgent)."
+      description "Creates a new task with a title, optional markdown description, and task state. To create a sub-task, provide a parent_task_id. Can also set assignees (array of user IDs), due_date, priority (low, medium, high, urgent), and dependencies (array of task IDs that must be completed before this task)."
     end
 
     tool :update_task, Citadel.Tasks.Task, :update do
@@ -26,6 +26,14 @@ defmodule Citadel.Tasks do
 
     tool :delete_task, Citadel.Tasks.Task, :destroy do
       description "Deletes an existing task by ID. Sub-tasks will also be deleted."
+    end
+
+    tool :create_task_dependency, Citadel.Tasks.TaskDependency, :create do
+      description "Creates a dependency between two tasks. The task specified by task_id will depend on (be blocked by) the task specified by depends_on_task_id."
+    end
+
+    tool :delete_task_dependency, Citadel.Tasks.TaskDependency, :destroy do
+      description "Deletes an existing task dependency by its ID"
     end
   end
 

--- a/lib/citadel/tasks/task.ex
+++ b/lib/citadel/tasks/task.ex
@@ -49,12 +49,14 @@ defmodule Citadel.Tasks.Task do
       ]
 
       argument :assignees, {:array, :uuid}
+      argument :dependencies, {:array, :uuid}
 
       change relate_actor(:user)
       change Citadel.Tasks.Changes.InheritParentWorkspace
       change Citadel.Tasks.Changes.AssignHumanId
       change Citadel.Tasks.Changes.SetDefaultTaskState
       change manage_relationship(:assignees, type: :append_and_remove, on_lookup: :relate)
+      change manage_relationship(:dependencies, type: :append_and_remove, on_lookup: :relate)
 
       validate Citadel.Tasks.Validations.NoCircularParent
       validate Citadel.Tasks.Validations.AssigneesWorkspaceMembers

--- a/lib/citadel/tasks/task_dependency.ex
+++ b/lib/citadel/tasks/task_dependency.ex
@@ -28,7 +28,12 @@ defmodule Citadel.Tasks.TaskDependency do
   end
 
   actions do
-    defaults [:read, :destroy, create: :*]
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+      accept [:task_id, :depends_on_task_id]
+    end
 
     update :update do
       primary? true

--- a/lib/citadel/tasks/validations/no_circular_dependency.ex
+++ b/lib/citadel/tasks/validations/no_circular_dependency.ex
@@ -21,6 +21,9 @@ defmodule Citadel.Tasks.Validations.NoCircularDependency do
 
   defp validate_no_circular_dependency(task_id, depends_on_task_id) do
     cond do
+      is_nil(task_id) or is_nil(depends_on_task_id) ->
+        :ok
+
       task_id == depends_on_task_id ->
         {:error, field: :depends_on_task_id, message: "a task cannot depend on itself"}
 

--- a/lib/citadel_web/router.ex
+++ b/lib/citadel_web/router.ex
@@ -97,7 +97,9 @@ defmodule CitadelWeb.Router do
         :list_tasks,
         :create_task,
         :update_task,
-        :list_task_states
+        :list_task_states,
+        :create_task_dependency,
+        :delete_task_dependency
       ],
       # For many tools, you will need to set the `protocol_version_statement` to the older version.
       protocol_version_statement: "2024-11-05",

--- a/test/citadel/tasks/mcp_task_dependency_test.exs
+++ b/test/citadel/tasks/mcp_task_dependency_test.exs
@@ -1,0 +1,207 @@
+defmodule Citadel.Tasks.McpTaskDependencyTest do
+  use Citadel.DataCase
+
+  alias Citadel.Tasks
+
+  setup do
+    all_states = Tasks.list_task_states!(authorize?: false)
+    incomplete_states = Enum.filter(all_states, &(&1.is_complete == false))
+
+    todo_state = Enum.at(incomplete_states, 0)
+
+    %{todo_state: todo_state}
+  end
+
+  describe "MCP create_task_dependency tool" do
+    setup context do
+      user = generate(user())
+      workspace = generate(workspace([], actor: user))
+
+      task_a =
+        generate(task([task_state_id: context.todo_state.id], actor: user, tenant: workspace.id))
+
+      task_b =
+        generate(task([task_state_id: context.todo_state.id], actor: user, tenant: workspace.id))
+
+      %{user: user, workspace: workspace, task_a: task_a, task_b: task_b}
+    end
+
+    test "creates a valid dependency between two tasks", %{
+      user: user,
+      workspace: workspace,
+      task_a: task_a,
+      task_b: task_b
+    } do
+      assert {:ok, dependency} =
+               Tasks.create_task_dependency(
+                 %{task_id: task_a.id, depends_on_task_id: task_b.id},
+                 actor: user,
+                 tenant: workspace.id
+               )
+
+      assert dependency.task_id == task_a.id
+      assert dependency.depends_on_task_id == task_b.id
+    end
+
+    test "fails for self-referential dependency", %{
+      user: user,
+      workspace: workspace,
+      task_a: task_a
+    } do
+      assert {:error, %Ash.Error.Invalid{} = error} =
+               Tasks.create_task_dependency(
+                 %{task_id: task_a.id, depends_on_task_id: task_a.id},
+                 actor: user,
+                 tenant: workspace.id
+               )
+
+      assert Exception.message(error) =~ "a task cannot depend on itself"
+    end
+
+    test "fails for circular dependency", %{
+      user: user,
+      workspace: workspace,
+      task_a: task_a,
+      task_b: task_b,
+      todo_state: todo_state
+    } do
+      task_c =
+        generate(task([task_state_id: todo_state.id], actor: user, tenant: workspace.id))
+
+      Tasks.create_task_dependency!(
+        %{task_id: task_a.id, depends_on_task_id: task_b.id},
+        actor: user,
+        tenant: workspace.id
+      )
+
+      Tasks.create_task_dependency!(
+        %{task_id: task_b.id, depends_on_task_id: task_c.id},
+        actor: user,
+        tenant: workspace.id
+      )
+
+      assert {:error, %Ash.Error.Invalid{} = error} =
+               Tasks.create_task_dependency(
+                 %{task_id: task_c.id, depends_on_task_id: task_a.id},
+                 actor: user,
+                 tenant: workspace.id
+               )
+
+      assert Exception.message(error) =~ "circular"
+    end
+  end
+
+  describe "MCP delete_task_dependency tool" do
+    setup context do
+      user = generate(user())
+      workspace = generate(workspace([], actor: user))
+
+      task_a =
+        generate(task([task_state_id: context.todo_state.id], actor: user, tenant: workspace.id))
+
+      task_b =
+        generate(task([task_state_id: context.todo_state.id], actor: user, tenant: workspace.id))
+
+      %{user: user, workspace: workspace, task_a: task_a, task_b: task_b}
+    end
+
+    test "removes an existing dependency", %{
+      user: user,
+      workspace: workspace,
+      task_a: task_a,
+      task_b: task_b
+    } do
+      dependency =
+        Tasks.create_task_dependency!(
+          %{task_id: task_a.id, depends_on_task_id: task_b.id},
+          actor: user,
+          tenant: workspace.id
+        )
+
+      assert :ok = Tasks.destroy_task_dependency(dependency, actor: user)
+
+      dependencies = Tasks.list_task_dependencies!(task_a.id, actor: user, tenant: workspace.id)
+      assert dependencies == []
+    end
+  end
+
+  describe "Task create with dependencies argument" do
+    setup context do
+      user = generate(user())
+      workspace = generate(workspace([], actor: user))
+      %{user: user, workspace: workspace, todo_state: context.todo_state}
+    end
+
+    test "creates a task with initial dependencies", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state
+    } do
+      dep_task_1 =
+        generate(task([task_state_id: todo_state.id], actor: user, tenant: workspace.id))
+
+      dep_task_2 =
+        generate(task([task_state_id: todo_state.id], actor: user, tenant: workspace.id))
+
+      assert {:ok, task} =
+               Tasks.create_task(
+                 %{
+                   title: "Task with dependencies",
+                   task_state_id: todo_state.id,
+                   workspace_id: workspace.id,
+                   dependencies: [dep_task_1.id, dep_task_2.id]
+                 },
+                 actor: user,
+                 tenant: workspace.id
+               )
+
+      task = Ash.load!(task, [:dependencies], authorize?: false)
+
+      assert length(task.dependencies) == 2
+      dependency_ids = Enum.map(task.dependencies, & &1.id)
+      assert dep_task_1.id in dependency_ids
+      assert dep_task_2.id in dependency_ids
+    end
+
+    test "creates a task with empty dependencies array", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state
+    } do
+      assert {:ok, task} =
+               Tasks.create_task(
+                 %{
+                   title: "Task without dependencies",
+                   task_state_id: todo_state.id,
+                   workspace_id: workspace.id,
+                   dependencies: []
+                 },
+                 actor: user,
+                 tenant: workspace.id
+               )
+
+      task = Ash.load!(task, [:dependencies], authorize?: false)
+      assert task.dependencies == []
+    end
+
+    test "creates a task without dependencies argument", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state
+    } do
+      assert {:ok, task} =
+               Tasks.create_task(
+                 %{
+                   title: "Task no deps arg",
+                   task_state_id: todo_state.id,
+                   workspace_id: workspace.id
+                 },
+                 actor: user,
+                 tenant: workspace.id
+               )
+
+      task = Ash.load!(task, [:dependencies], authorize?: false)
+      assert task.dependencies == []
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add MCP tools for task dependency management (`create_task_dependency`, `delete_task_dependency`)
- Enhance Task create action to accept `dependencies` argument for creating tasks with initial dependencies
- Fix NoCircularDependency validation to handle relationship management lifecycle

## Test plan
- [x] Verify `create_task_dependency` tool creates valid dependencies between tasks
- [x] Verify `create_task_dependency` fails for self-referential dependencies
- [x] Verify `create_task_dependency` fails for circular dependencies
- [x] Verify `delete_task_dependency` removes existing dependencies
- [x] Verify Task create with `dependencies` argument creates task with initial dependencies
- [x] Verify Task create with empty `dependencies` array works
- [x] Verify Task create without `dependencies` argument still works
- [x] Verify existing task dependency tests still pass
- [x] Run `mix ck` to verify code quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)