### PR TITLE
feat(P-13): filter out empty task states from rendering

### DIFF
--- a/assets/js/hooks/task_drag_drop.js
+++ b/assets/js/hooks/task_drag_drop.js
@@ -40,6 +40,10 @@ const TaskDragDrop = {
 
           // Only send event if the state actually changed
           if (oldStateId !== newStateId) {
+            // Move element back to original position - LiveView will handle the actual DOM update
+            // This prevents duplicates from Sortable moving the element AND LiveView inserting it
+            evt.from.insertBefore(evt.item, evt.from.children[evt.oldIndex])
+
             this.pushEventTo(this.el, "task-moved", {
               task_id: taskId,
               new_state_id: newStateId

--- a/assets/js/hooks/task_drag_drop.js
+++ b/assets/js/hooks/task_drag_drop.js
@@ -2,6 +2,19 @@ import Sortable from "../../vendor/sortable.js"
 
 const TaskDragDrop = {
   mounted() {
+    this.initSortables()
+  },
+
+  updated() {
+    this.destroySortables()
+    this.initSortables()
+  },
+
+  destroyed() {
+    this.destroySortables()
+  },
+
+  initSortables() {
     this.sortables = []
 
     // Find all dropzones (one per task state)
@@ -39,10 +52,11 @@ const TaskDragDrop = {
     })
   },
 
-  destroyed() {
-    // Clean up Sortable instances
-    this.sortables.forEach(sortable => sortable.destroy())
-    this.sortables = []
+  destroySortables() {
+    if (this.sortables) {
+      this.sortables.forEach(sortable => sortable.destroy())
+      this.sortables = []
+    }
   }
 }
 

--- a/lib/citadel_web/live/components/tasks_list_component.ex
+++ b/lib/citadel_web/live/components/tasks_list_component.ex
@@ -202,7 +202,7 @@ defmodule CitadelWeb.Components.TasksListComponent do
   def render(assigns) do
     ~H"""
     <table class="w-full" phx-hook="TaskDragDrop" id={@id} phx-target={@myself}>
-      <%= for state <- @task_states do %>
+      <%= for state <- @task_states, (@tasks_by_state_count[state.id] || 0) > 0 do %>
         <thead class="[&:not(:first-child)]:border-t [&:not(:first-child)]:border-border">
           <tr class="sticky top-0 bg-base-200 z-100">
             <td colspan="7" class="px-6 py-4">

--- a/lib/citadel_web/live/components/tasks_list_component.ex
+++ b/lib/citadel_web/live/components/tasks_list_component.ex
@@ -199,57 +199,74 @@ defmodule CitadelWeb.Components.TasksListComponent do
 
   defp dom_id(state_id, task_id), do: "tasks_#{state_id}-#{task_id}"
 
+  defp total_task_count(tasks_by_state_count) do
+    Enum.sum(Map.values(tasks_by_state_count))
+  end
+
   def render(assigns) do
+    assigns = assign(assigns, :total_count, total_task_count(assigns.tasks_by_state_count))
+
     ~H"""
-    <table class="w-full" phx-hook="TaskDragDrop" id={@id} phx-target={@myself}>
-      <%= for state <- @task_states, (@tasks_by_state_count[state.id] || 0) > 0 do %>
-        <thead class="[&:not(:first-child)]:border-t [&:not(:first-child)]:border-border">
-          <tr class="sticky top-0 bg-base-200 z-100">
-            <td colspan="7" class="px-6 py-4">
-              <div class="flex items-center justify-between">
-                <h2 class="text-lg font-semibold text-base-content">
-                  {state.name}
-                </h2>
-                <span class="badge badge-neutral badge-sm">
-                  {@tasks_by_state_count[state.id] || 0}
-                </span>
-              </div>
-            </td>
-          </tr>
-          <tr class="sticky top-[60px] bg-base-200 z-100">
-            <th></th>
-            <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 px-2"></th>
-            <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left px-2">
-              ID
-            </th>
-            <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left">Name</th>
-            <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left px-2">
-              Priority
-            </th>
-            <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left px-2">
-              Due Date
-            </th>
-            <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left px-2">
-              Assignee
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          id={"#{@id}-state-#{state.id}"}
-          phx-update="stream"
-          data-dropzone
-          data-state-id={state.id}
-        >
-          <.task_row
-            :for={{dom_id, task} <- @streams[stream_name(state.id)] || []}
-            id={dom_id}
-            task={task}
-            current_user={@current_user}
-            current_workspace={@current_workspace}
-          />
-        </tbody>
-      <% end %>
-    </table>
+    <div id={@id} phx-hook="TaskDragDrop" phx-target={@myself}>
+      <div
+        :if={@total_count == 0}
+        class="flex flex-col items-center justify-center py-16 text-base-content/50"
+      >
+        <.icon name="hero-clipboard-document-list" class="size-16 mb-4" />
+        <p class="text-lg">No tasks yet. Create one to get started!</p>
+      </div>
+      <table :if={@total_count > 0} class="w-full">
+        <%= for state <- @task_states, (@tasks_by_state_count[state.id] || 0) > 0 do %>
+          <thead class="[&:not(:first-child)]:border-t [&:not(:first-child)]:border-border">
+            <tr class="sticky top-0 bg-base-200 z-100">
+              <td colspan="7" class="px-6 py-4">
+                <div class="flex items-center justify-between">
+                  <h2 class="text-lg font-semibold text-base-content">
+                    {state.name}
+                  </h2>
+                  <span class="badge badge-neutral badge-sm">
+                    {@tasks_by_state_count[state.id] || 0}
+                  </span>
+                </div>
+              </td>
+            </tr>
+            <tr class="sticky top-[60px] bg-base-200 z-100">
+              <th></th>
+              <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 px-2"></th>
+              <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left px-2">
+                ID
+              </th>
+              <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left">
+                Name
+              </th>
+              <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left px-2">
+                Priority
+              </th>
+              <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left px-2">
+                Due Date
+              </th>
+              <th class="text-xs uppercase text-base-content/50 font-semibold pb-2 text-left px-2">
+                Assignee
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            id={"#{@id}-state-#{state.id}"}
+            phx-update="stream"
+            data-dropzone
+            data-state-id={state.id}
+          >
+            <.task_row
+              :for={{dom_id, task} <- @streams[stream_name(state.id)] || []}
+              id={dom_id}
+              task={task}
+              current_user={@current_user}
+              current_workspace={@current_workspace}
+            />
+          </tbody>
+        <% end %>
+      </table>
+    </div>
     """
   end
 end

--- a/test/citadel/billing/checks/has_feature_test.exs
+++ b/test/citadel/billing/checks/has_feature_test.exs
@@ -1,5 +1,5 @@
 defmodule Citadel.Billing.Checks.HasFeatureTest do
-  use Citadel.DataCase, async: true
+  use Citadel.DataCase, async: false
 
   import Citadel.Generator
 


### PR DESCRIPTION
## Summary
- Only render task states that have at least one task in `TasksListComponent`
- States automatically appear when tasks are added and disappear when empty
- Fix flaky `HasFeatureTest` by making it synchronous (uses global feature flag state)

## Test plan
- [x] `mix ck` passes
- [x] `mix test` passes (including with previously failing seed)
- [x] Verify empty task states are not shown in UI
- [x] Verify states appear when tasks are dragged into them
- [x] Verify states disappear when last task is removed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)