### PR TITLE
feat: add CitadelAgent.GitHub module for creating draft pull requests

### DIFF
--- a/citadel_agent/config/runtime.exs
+++ b/citadel_agent/config/runtime.exs
@@ -19,3 +19,7 @@ end
 if stall_timeout = System.get_env("CITADEL_STALL_TIMEOUT") do
   config :citadel_agent, stall_timeout_ms: String.to_integer(stall_timeout)
 end
+
+if token = System.get_env("GITHUB_TOKEN") do
+  config :citadel_agent, github_token: token
+end

--- a/citadel_agent/lib/citadel_agent/github.ex
+++ b/citadel_agent/lib/citadel_agent/github.ex
@@ -1,0 +1,73 @@
+defmodule CitadelAgent.GitHub do
+  require Logger
+
+  @github_api "https://api.github.com"
+
+  def create_pull_request(owner, repo, head, base, title, body) do
+    token = CitadelAgent.config(:github_token)
+
+    unless token do
+      {:error, "GITHUB_TOKEN not configured"}
+    else
+      url = "#{@github_api}/repos/#{owner}/#{repo}/pulls"
+
+      case Req.post(url,
+             json: %{title: title, body: body, head: head, base: base, draft: true},
+             headers: [
+               {"authorization", "Bearer #{token}"},
+               {"accept", "application/vnd.github+v3+json"}
+             ]
+           ) do
+        {:ok, %Req.Response{status: status, body: body}} when status in [201] ->
+          {:ok, body["html_url"]}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          message = body["message"] || "HTTP #{status}"
+          Logger.warning("GitHub API error: #{status} - #{message}")
+          {:error, message}
+
+        {:error, exception} ->
+          Logger.warning("GitHub API request failed: #{Exception.message(exception)}")
+          {:error, Exception.message(exception)}
+      end
+    end
+  end
+
+  def parse_remote_url(project_path) do
+    case System.cmd("git", ["remote", "get-url", "origin"],
+           cd: project_path,
+           stderr_to_stdout: true
+         ) do
+      {url, 0} ->
+        url = String.trim(url)
+        parse_url(url)
+
+      {output, _code} ->
+        {:error, "Failed to get remote URL: #{String.trim(output)}"}
+    end
+  end
+
+  defp parse_url("git@github.com:" <> rest) do
+    extract_owner_repo(rest)
+  end
+
+  defp parse_url("https://github.com/" <> rest) do
+    extract_owner_repo(rest)
+  end
+
+  defp parse_url(url) do
+    {:error, "Unrecognized remote URL format: #{url}"}
+  end
+
+  defp extract_owner_repo(path) do
+    path = String.trim_trailing(path, ".git")
+
+    case String.split(path, "/", parts: 2) do
+      [owner, repo] when owner != "" and repo != "" ->
+        {:ok, {owner, repo}}
+
+      _ ->
+        {:error, "Could not extract owner/repo from: #{path}"}
+    end
+  end
+end

--- a/citadel_agent/test/citadel_agent/github_test.exs
+++ b/citadel_agent/test/citadel_agent/github_test.exs
@@ -1,0 +1,67 @@
+defmodule CitadelAgent.GitHubTest do
+  use ExUnit.Case, async: true
+
+  alias CitadelAgent.GitHub
+
+  describe "parse_remote_url/1" do
+    test "parses SSH remote URL" do
+      dir = setup_git_repo("git@github.com:jwstover/citadel.git")
+      assert {:ok, {"jwstover", "citadel"}} = GitHub.parse_remote_url(dir)
+    end
+
+    test "parses HTTPS remote URL" do
+      dir = setup_git_repo("https://github.com/jwstover/citadel.git")
+      assert {:ok, {"jwstover", "citadel"}} = GitHub.parse_remote_url(dir)
+    end
+
+    test "strips trailing .git" do
+      dir = setup_git_repo("git@github.com:owner/repo.git")
+      assert {:ok, {"owner", "repo"}} = GitHub.parse_remote_url(dir)
+    end
+
+    test "handles URLs without .git suffix" do
+      dir = setup_git_repo("https://github.com/owner/repo")
+      assert {:ok, {"owner", "repo"}} = GitHub.parse_remote_url(dir)
+    end
+
+    test "returns error for unrecognized format" do
+      dir = setup_git_repo("https://gitlab.com/owner/repo.git")
+      assert {:error, "Unrecognized remote URL format:" <> _} = GitHub.parse_remote_url(dir)
+    end
+
+    test "returns error when no remote exists" do
+      dir = System.tmp_dir!() |> Path.join("github_test_no_remote_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      System.cmd("git", ["init"], cd: dir)
+
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      assert {:error, _} = GitHub.parse_remote_url(dir)
+    end
+
+    defp setup_git_repo(remote_url) do
+      dir = System.tmp_dir!() |> Path.join("github_test_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      System.cmd("git", ["init"], cd: dir)
+      System.cmd("git", ["remote", "add", "origin", remote_url], cd: dir)
+
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      dir
+    end
+  end
+
+  describe "create_pull_request/6" do
+    test "returns error when token is not configured" do
+      original = Application.get_env(:citadel_agent, :github_token)
+      Application.delete_env(:citadel_agent, :github_token)
+
+      on_exit(fn ->
+        if original, do: Application.put_env(:citadel_agent, :github_token, original)
+      end)
+
+      assert {:error, "GITHUB_TOKEN not configured"} =
+               GitHub.create_pull_request("owner", "repo", "feature", "main", "Title", "Body")
+    end
+  end
+end


### PR DESCRIPTION
Adds a GitHub API integration module with:
- `create_pull_request/6` to POST draft PRs to the GitHub API using a PAT
- `parse_remote_url/1` to extract owner/repo from SSH and HTTPS remote URLs
- GITHUB_TOKEN wired up in config/runtime.exs