### PR TITLE
feat: add generate_pr_description/2 to Runner for AI-generated PR des…

### DIFF
--- a/citadel_agent/lib/citadel_agent/runner.ex
+++ b/citadel_agent/lib/citadel_agent/runner.ex
@@ -342,6 +342,83 @@ defmodule CitadelAgent.Runner do
 
   defp maybe_commit_and_push(_claude_result, _task, _worktree_path, _branch_name), do: :ok
 
+  def generate_pr_description(task, project_path) do
+    title = task["title"] || ""
+    description = task["description"] || ""
+
+    prompt = """
+    Generate a concise GitHub pull request description in markdown for the following task. \
+    Output ONLY the description text, nothing else. Do not use any tools or make any code changes.
+
+    Task: #{title}
+
+    #{description}
+    """
+
+    case run_claude_cli(String.trim(prompt),
+           working_dir: project_path,
+           label: "pr-desc:#{task["human_id"]}",
+           timeout: @commit_stall_timeout,
+           model: "sonnet"
+         ) do
+      {:ok, %{exit_code: 0, output: output}} ->
+        case extract_text_from_stream_json(output) do
+          nil -> {:ok, fallback_pr_description(title)}
+          text -> {:ok, text}
+        end
+
+      {:ok, %{exit_code: _code}} ->
+        Logger.warning("PR description generation failed, using fallback")
+        {:ok, fallback_pr_description(title)}
+
+      {:error, reason} ->
+        Logger.warning("PR description generation failed: #{inspect(reason)}, using fallback")
+        {:ok, fallback_pr_description(title)}
+    end
+  end
+
+  @doc false
+  def extract_text_from_stream_json(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.reduce([], fn line, acc ->
+      case Jason.decode(line) do
+        {:ok, %{"type" => "assistant", "message" => %{"content" => content}}} ->
+          text =
+            content
+            |> Enum.filter(&(&1["type"] == "text"))
+            |> Enum.map_join("", & &1["text"])
+
+          [text | acc]
+
+        {:ok, %{"type" => "content_block_delta", "delta" => %{"text" => text}}} ->
+          [text | acc]
+
+        {:ok, %{"type" => "result", "result" => result}} ->
+          text =
+            (result["content"] || [])
+            |> Enum.filter(&(&1["type"] == "text"))
+            |> Enum.map_join("", & &1["text"])
+
+          [text | acc]
+
+        _ ->
+          acc
+      end
+    end)
+    |> Enum.reverse()
+    |> Enum.join("")
+    |> String.trim()
+    |> case do
+      "" -> nil
+      text -> text
+    end
+  end
+
+  defp fallback_pr_description(title) do
+    "Citadel task: #{title}"
+  end
+
   defp run_claude(task, worktree_path) do
     human_id = task["human_id"]
 

--- a/citadel_agent/test/citadel_agent/runner_pr_description_test.exs
+++ b/citadel_agent/test/citadel_agent/runner_pr_description_test.exs
@@ -1,0 +1,89 @@
+defmodule CitadelAgent.RunnerPrDescriptionTest do
+  use ExUnit.Case, async: true
+
+  describe "generate_pr_description/2" do
+    @moduletag :tmp_dir
+
+    setup %{tmp_dir: tmp_dir} do
+      System.cmd("git", ["init", "-b", "main"], cd: tmp_dir)
+      {:ok, project_path: tmp_dir}
+    end
+
+    test "returns fallback description when CLI is unavailable", %{project_path: project_path} do
+      task = %{
+        "human_id" => "TEST-PR-1",
+        "title" => "Add user settings page",
+        "description" => "Create a new settings page for users"
+      }
+
+      assert {:ok, description} = CitadelAgent.Runner.generate_pr_description(task, project_path)
+      assert is_binary(description)
+      assert String.length(description) > 0
+    end
+
+    test "returns fallback with task title on error", %{project_path: project_path} do
+      task = %{
+        "human_id" => "TEST-PR-2",
+        "title" => "Fix login bug",
+        "description" => nil
+      }
+
+      assert {:ok, description} = CitadelAgent.Runner.generate_pr_description(task, project_path)
+      assert description =~ "Fix login bug"
+    end
+
+    test "handles task with nil title gracefully", %{project_path: project_path} do
+      task = %{
+        "human_id" => "TEST-PR-3",
+        "title" => nil,
+        "description" => nil
+      }
+
+      assert {:ok, description} = CitadelAgent.Runner.generate_pr_description(task, project_path)
+      assert is_binary(description)
+    end
+  end
+
+  describe "extract_text_from_stream_json/1" do
+    test "extracts text from result type" do
+      output = ~s|{"type":"result","result":{"content":[{"type":"text","text":"## Summary\\nFixes the login bug"}]}}|
+
+      assert CitadelAgent.Runner.extract_text_from_stream_json(output) ==
+               "## Summary\nFixes the login bug"
+    end
+
+    test "extracts text from assistant message type" do
+      output = ~s|{"type":"assistant","message":{"content":[{"type":"text","text":"PR description here"}]}}|
+
+      assert CitadelAgent.Runner.extract_text_from_stream_json(output) == "PR description here"
+    end
+
+    test "extracts text from content_block_delta events" do
+      output = """
+      {"type":"content_block_delta","delta":{"text":"Hello "}}
+      {"type":"content_block_delta","delta":{"text":"world"}}
+      """
+
+      assert CitadelAgent.Runner.extract_text_from_stream_json(output) == "Hello world"
+    end
+
+    test "returns nil for empty output" do
+      assert CitadelAgent.Runner.extract_text_from_stream_json("") == nil
+    end
+
+    test "returns nil when no text content found" do
+      output = ~s|{"type":"system","message":"starting"}|
+      assert CitadelAgent.Runner.extract_text_from_stream_json(output) == nil
+    end
+
+    test "ignores non-JSON lines" do
+      output = """
+      not json
+      {"type":"result","result":{"content":[{"type":"text","text":"good output"}]}}
+      also not json
+      """
+
+      assert CitadelAgent.Runner.extract_text_from_stream_json(output) == "good output"
+    end
+  end
+end


### PR DESCRIPTION
…criptions

Uses run_claude_cli/2 with the sonnet model and commit stall timeout to generate concise markdown PR descriptions from task context. Falls back to a simple "Citadel task: <title>" string on any failure so it never blocks the workflow.