### PR TITLE
feat(agent): relay stream events from runner to PubSub via AgentChannel

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,12 +28,13 @@ import TaskDragDrop from "./hooks/task_drag_drop.js"
 import Clipboard from "./hooks/clipboard.js"
 import MilkdownEditor from "./hooks/milkdown_editor.js"
 import CmdEnterSubmit from "./hooks/cmd_enter_submit.js"
+import AutoScroll from "./hooks/auto_scroll.js"
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, TaskDragDrop, Clipboard, MilkdownEditor, CmdEnterSubmit},
+  hooks: {...colocatedHooks, TaskDragDrop, Clipboard, MilkdownEditor, CmdEnterSubmit, AutoScroll},
 })
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/hooks/auto_scroll.js
+++ b/assets/js/hooks/auto_scroll.js
@@ -1,0 +1,16 @@
+const AutoScroll = {
+  mounted() {
+    this.shouldAutoScroll = true
+    this.el.addEventListener("scroll", () => {
+      const { scrollTop, scrollHeight, clientHeight } = this.el
+      this.shouldAutoScroll = scrollHeight - scrollTop - clientHeight < 50
+    })
+  },
+  updated() {
+    if (this.shouldAutoScroll) {
+      this.el.scrollTop = this.el.scrollHeight
+    }
+  }
+}
+
+export default AutoScroll

--- a/citadel_agent/lib/citadel_agent/runner.ex
+++ b/citadel_agent/lib/citadel_agent/runner.ex
@@ -13,8 +13,9 @@ defmodule CitadelAgent.Runner do
 
   @commit_stall_timeout 120_000
 
-  def execute(task, project_path) do
+  def execute(task, project_path, opts \\ []) do
     human_id = task["human_id"]
+    run_id = Keyword.get(opts, :run_id)
     branch_name = "citadel/task-#{human_id}"
     worktree_path = Path.join(project_path, ".worktrees/task-#{human_id}")
     base_branch = base_branch_for(task)
@@ -24,7 +25,7 @@ defmodule CitadelAgent.Runner do
          :ok <- create_worktree(worktree_path, branch_name, base_branch, project_path) do
       result =
         try do
-          with {:ok, claude_result} <- run_claude(task, worktree_path),
+          with {:ok, claude_result} <- run_claude(task, worktree_path, run_id: run_id),
                :ok <- maybe_commit_and_push(claude_result, task, worktree_path, branch_name),
                {:ok, diff} <- capture_diff(worktree_path, base_branch, branch_name) do
             {:ok,
@@ -492,13 +493,15 @@ defmodule CitadelAgent.Runner do
     "Citadel task: #{title}"
   end
 
-  defp run_claude(task, worktree_path) do
+  defp run_claude(task, worktree_path, opts) do
     human_id = task["human_id"]
+    run_id = Keyword.get(opts, :run_id)
 
     run_claude_cli(build_prompt(task),
       working_dir: worktree_path,
       label: human_id,
-      timeout: stall_timeout()
+      timeout: stall_timeout(),
+      run_id: run_id
     )
   end
 
@@ -507,6 +510,7 @@ defmodule CitadelAgent.Runner do
     label = Keyword.get(opts, :label, "claude")
     timeout = Keyword.get(opts, :timeout, stall_timeout())
     model = Keyword.get(opts, :model)
+    run_id = Keyword.get(opts, :run_id)
 
     Logger.info("Executing Claude Code CLI for #{label} (stall timeout: #{timeout}ms)")
 
@@ -522,18 +526,22 @@ defmodule CitadelAgent.Runner do
 
       port = Port.open({:spawn, cmd}, [:binary, :exit_status, cd: working_dir])
 
-      collect_port_output(port, label, [], timeout)
+      collect_port_output(port, label, [], timeout, run_id)
     end
   end
 
-  defp collect_port_output(port, human_id, acc, timeout) do
+  defp collect_port_output(port, human_id, acc, timeout, run_id) do
     receive do
       {^port, {:data, data}} ->
-        for line <- String.split(data, "\n", trim: true) do
+        lines = String.split(data, "\n", trim: true)
+
+        for line <- lines do
           Logger.info("[claude:#{human_id}] #{line}")
         end
 
-        collect_port_output(port, human_id, [data | acc], timeout)
+        push_lines_to_stream(run_id, lines)
+
+        collect_port_output(port, human_id, [data | acc], timeout, run_id)
 
       {^port, {:exit_status, code}} ->
         output = acc |> Enum.reverse() |> IO.iodata_to_binary()
@@ -548,6 +556,24 @@ defmodule CitadelAgent.Runner do
          "Claude Code process stalled after #{div(timeout, 1_000)}s of inactivity. " <>
            "Partial output (#{byte_size(output)} bytes) captured before kill."}
     end
+  end
+
+  defp push_lines_to_stream(nil, _lines), do: :ok
+
+  defp push_lines_to_stream(run_id, lines) do
+    for line <- lines do
+      trimmed = String.trim(line)
+
+      if trimmed != "" do
+        try do
+          CitadelAgent.Socket.push_stream_event(run_id, trimmed)
+        rescue
+          e -> Logger.debug("Failed to push stream event: #{Exception.message(e)}")
+        end
+      end
+    end
+
+    :ok
   end
 
   defp kill_port(port) do

--- a/citadel_agent/lib/citadel_agent/socket.ex
+++ b/citadel_agent/lib/citadel_agent/socket.ex
@@ -16,6 +16,14 @@ defmodule CitadelAgent.Socket do
     GenServer.cast(__MODULE__, {:update_status, status, current_task_id})
   end
 
+  def push_stream_event(run_id, line) do
+    GenServer.cast(__MODULE__, {:push_stream_event, run_id, line})
+  end
+
+  def push_stream_complete(run_id) do
+    GenServer.cast(__MODULE__, {:push_stream_complete, run_id})
+  end
+
   @impl true
   def init(_opts) do
     agent_name = CitadelAgent.config(:agent_name) || "citadel-agent"
@@ -64,6 +72,16 @@ defmodule CitadelAgent.Socket do
     }
 
     push(socket, "agents:lobby", "update_status", payload)
+    {:noreply, socket}
+  end
+
+  def handle_cast({:push_stream_event, run_id, line}, socket) do
+    push(socket, "agents:lobby", "stream_output", %{"run_id" => run_id, "event" => line})
+    {:noreply, socket}
+  end
+
+  def handle_cast({:push_stream_complete, run_id}, socket) do
+    push(socket, "agents:lobby", "stream_complete", %{"run_id" => run_id})
     {:noreply, socket}
   end
 

--- a/citadel_agent/lib/citadel_agent/worker.ex
+++ b/citadel_agent/lib/citadel_agent/worker.ex
@@ -81,9 +81,11 @@ defmodule CitadelAgent.Worker do
   end
 
   defp run_task(task, run, project_path) do
-    case CitadelAgent.Runner.execute(task, project_path) do
+    run_id = run["id"]
+
+    case CitadelAgent.Runner.execute(task, project_path, run_id: run_id) do
       {:ok, result} ->
-        CitadelAgent.Client.update_run(run["id"], %{
+        CitadelAgent.Client.update_run(run_id, %{
           "status" => result.status,
           "diff" => result.diff,
           "logs" => result.logs,
@@ -92,19 +94,21 @@ defmodule CitadelAgent.Worker do
         })
 
         Logger.info("Task #{task["human_id"]} completed with status: #{result.status}")
+        push_stream_complete(run_id)
 
         if result.status == "completed" do
           transition_task_to_in_review(task)
         end
 
       {:error, reason} ->
-        CitadelAgent.Client.update_run(run["id"], %{
+        CitadelAgent.Client.update_run(run_id, %{
           "status" => "failed",
           "error_message" => inspect(reason),
           "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
         })
 
         Logger.error("Task #{task["human_id"]} failed: #{inspect(reason)}")
+        push_stream_complete(run_id)
     end
   rescue
     exception ->
@@ -117,6 +121,16 @@ defmodule CitadelAgent.Worker do
         "error_message" => Exception.message(exception),
         "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
       })
+
+      push_stream_complete(run["id"])
+  end
+
+  defp push_stream_complete(run_id) do
+    try do
+      CitadelAgent.Socket.push_stream_complete(run_id)
+    rescue
+      e -> Logger.debug("Failed to push stream_complete: #{Exception.message(e)}")
+    end
   end
 
   defp transition_task_to_in_review(task) do

--- a/lib/citadel/agent/stream_parser.ex
+++ b/lib/citadel/agent/stream_parser.ex
@@ -26,7 +26,8 @@ defmodule Citadel.Agent.StreamParser do
       subtype: event["subtype"],
       session_id: event["session_id"],
       tools: event["tools"],
-      model: event["model"]
+      model: event["model"],
+      tasks: event["tasks"]
     }
   end
 
@@ -81,6 +82,10 @@ defmodule Citadel.Agent.StreamParser do
 
   defp parse_content_block(%{"type" => "text", "text" => text}) do
     %{type: :text, text: text}
+  end
+
+  defp parse_content_block(%{"type" => "thinking", "thinking" => thinking}) do
+    %{type: :thinking, text: thinking}
   end
 
   defp parse_content_block(%{"type" => "tool_use", "name" => name, "input" => input, "id" => id}) do

--- a/lib/citadel/agent/stream_parser.ex
+++ b/lib/citadel/agent/stream_parser.ex
@@ -27,7 +27,8 @@ defmodule Citadel.Agent.StreamParser do
       session_id: event["session_id"],
       tools: event["tools"],
       model: event["model"],
-      tasks: event["tasks"]
+      tasks: event["tasks"],
+      parent_tool_use_id: event["parent_tool_use_id"]
     }
   end
 
@@ -38,7 +39,8 @@ defmodule Citadel.Agent.StreamParser do
       type: :assistant,
       blocks: blocks,
       model: get_in(event, ["message", "model"]),
-      session_id: event["session_id"]
+      session_id: event["session_id"],
+      parent_tool_use_id: event["parent_tool_use_id"]
     }
   end
 
@@ -49,7 +51,8 @@ defmodule Citadel.Agent.StreamParser do
       type: :tool_result,
       results: results,
       session_id: event["session_id"],
-      tool_use_result: event["tool_use_result"]
+      tool_use_result: event["tool_use_result"],
+      parent_tool_use_id: event["parent_tool_use_id"]
     }
   end
 
@@ -64,7 +67,8 @@ defmodule Citadel.Agent.StreamParser do
       num_turns: event["num_turns"],
       total_cost_usd: event["total_cost_usd"],
       usage: event["usage"],
-      session_id: event["session_id"]
+      session_id: event["session_id"],
+      parent_tool_use_id: event["parent_tool_use_id"]
     }
   end
 
@@ -103,6 +107,15 @@ defmodule Citadel.Agent.StreamParser do
       type: :tool_result,
       tool_use_id: id,
       content: content,
+      is_error: Map.get(block, "is_error", false)
+    }
+  end
+
+  defp parse_tool_result_block(%{"type" => "tool_result", "tool_use_id" => id} = block) do
+    %{
+      type: :tool_result,
+      tool_use_id: id,
+      content: nil,
       is_error: Map.get(block, "is_error", false)
     }
   end

--- a/lib/citadel/agent/stream_parser.ex
+++ b/lib/citadel/agent/stream_parser.ex
@@ -1,0 +1,108 @@
+defmodule Citadel.Agent.StreamParser do
+  @moduledoc """
+  Parses Claude Code `--output-format stream-json` lines into structured Elixir maps.
+
+  Each line of stream-json output is a JSON object with a `"type"` field. This module
+  decodes each line and normalizes it into a map with atom keys for the type.
+  """
+
+  @doc """
+  Parses a single line of stream-json output into a structured map.
+
+  Returns a map with `:type` as an atom and relevant fields extracted from the JSON.
+  Unknown event types return `%{type: :unknown, raw: decoded_map}`.
+  Invalid JSON returns `%{type: :error, raw: original_string}`.
+  """
+  def parse(line) when is_binary(line) do
+    case Jason.decode(line) do
+      {:ok, decoded} -> parse_event(decoded)
+      {:error, _} -> %{type: :error, raw: line}
+    end
+  end
+
+  defp parse_event(%{"type" => "system"} = event) do
+    %{
+      type: :system,
+      subtype: event["subtype"],
+      session_id: event["session_id"],
+      tools: event["tools"],
+      model: event["model"]
+    }
+  end
+
+  defp parse_event(%{"type" => "assistant", "message" => %{"content" => content}} = event) do
+    blocks = Enum.map(content, &parse_content_block/1)
+
+    %{
+      type: :assistant,
+      blocks: blocks,
+      model: get_in(event, ["message", "model"]),
+      session_id: event["session_id"]
+    }
+  end
+
+  defp parse_event(%{"type" => "user", "message" => %{"content" => content}} = event) do
+    results = Enum.map(content, &parse_tool_result_block/1)
+
+    %{
+      type: :tool_result,
+      results: results,
+      session_id: event["session_id"],
+      tool_use_result: event["tool_use_result"]
+    }
+  end
+
+  defp parse_event(%{"type" => "result"} = event) do
+    %{
+      type: :result,
+      subtype: event["subtype"],
+      result: event["result"],
+      is_error: event["is_error"],
+      stop_reason: event["stop_reason"],
+      duration_ms: event["duration_ms"],
+      num_turns: event["num_turns"],
+      total_cost_usd: event["total_cost_usd"],
+      usage: event["usage"],
+      session_id: event["session_id"]
+    }
+  end
+
+  defp parse_event(%{"type" => "rate_limit_event"} = event) do
+    %{
+      type: :rate_limit_event,
+      rate_limit_info: event["rate_limit_info"],
+      session_id: event["session_id"]
+    }
+  end
+
+  defp parse_event(decoded) do
+    %{type: :unknown, raw: decoded}
+  end
+
+  defp parse_content_block(%{"type" => "text", "text" => text}) do
+    %{type: :text, text: text}
+  end
+
+  defp parse_content_block(%{"type" => "tool_use", "name" => name, "input" => input, "id" => id}) do
+    %{type: :tool_use, tool: name, input: input, id: id}
+  end
+
+  defp parse_content_block(block) do
+    %{type: :unknown, raw: block}
+  end
+
+  defp parse_tool_result_block(
+         %{"type" => "tool_result", "tool_use_id" => id, "content" => content} = block
+       ) do
+    %{
+      type: :tool_result,
+      tool_use_id: id,
+      content: content,
+      is_error: Map.get(block, "is_error", false)
+    }
+  end
+
+  defp parse_tool_result_block(block) do
+    %{type: :unknown, raw: block}
+  end
+end

--- a/lib/citadel_web/channels/agent_channel.ex
+++ b/lib/citadel_web/channels/agent_channel.ex
@@ -3,6 +3,8 @@ defmodule CitadelWeb.AgentChannel do
 
   use Phoenix.Channel
 
+  require Logger
+
   alias CitadelWeb.AgentPresence
 
   @impl true
@@ -38,6 +40,27 @@ defmodule CitadelWeb.AgentChannel do
       |> Map.put(:status, status)
       |> Map.put(:current_task_id, payload["current_task_id"])
     end)
+
+    {:noreply, socket}
+  end
+
+  def handle_in("stream_output", %{"run_id" => run_id, "event" => event_data}, socket) do
+    CitadelWeb.Endpoint.broadcast("agent_run_output:#{run_id}", "stream_event", %{
+      event: event_data
+    })
+
+    {:noreply, socket}
+  end
+
+  def handle_in("stream_complete", %{"run_id" => run_id}, socket) do
+    CitadelWeb.Endpoint.broadcast("agent_run_output:#{run_id}", "stream_complete", %{})
+    {:noreply, socket}
+  end
+
+  def handle_in(event, payload, socket) do
+    Logger.warning(
+      "AgentChannel received unrecognized event: #{event}, payload: #{inspect(payload)}"
+    )
 
     {:noreply, socket}
   end

--- a/lib/citadel_web/components/agent_run_components.ex
+++ b/lib/citadel_web/components/agent_run_components.ex
@@ -1,4 +1,5 @@
 defmodule CitadelWeb.AgentRunComponents do
+  @moduledoc false
   use Phoenix.Component
 
   import CitadelWeb.CoreComponents

--- a/lib/citadel_web/components/agent_run_components.ex
+++ b/lib/citadel_web/components/agent_run_components.ex
@@ -1,0 +1,175 @@
+defmodule CitadelWeb.AgentRunComponents do
+  use Phoenix.Component
+
+  import CitadelWeb.CoreComponents
+
+  attr :event, :map, required: true
+
+  def stream_event(%{event: %{type: :assistant}} = assigns) do
+    ~H"""
+    <div class="space-y-3">
+      <div :for={block <- @event.blocks} class="flex gap-2">
+        <.assistant_block block={block} />
+      </div>
+    </div>
+    """
+  end
+
+  def stream_event(%{event: %{type: :tool_result}} = assigns) do
+    ~H"""
+    <div class="space-y-2">
+      <div :for={result <- @event.results}>
+        <.tool_result_block result={result} />
+      </div>
+    </div>
+    """
+  end
+
+  def stream_event(%{event: %{type: :result}} = assigns) do
+    ~H"""
+    <div class="rounded-lg bg-base-200 border border-base-300 p-3 text-sm">
+      <div class="flex items-center gap-2 text-base-content/70">
+        <.icon name="hero-flag" class="size-4 shrink-0" />
+        <span class="font-medium">
+          {result_label(@event)}
+        </span>
+      </div>
+      <div :if={@event[:duration_ms]} class="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-xs text-base-content/50">
+        <span>{format_duration(@event.duration_ms)}</span>
+        <span :if={@event[:num_turns]}>{@event.num_turns} turns</span>
+        <span :if={@event[:total_cost_usd]}>{"$#{Float.round(@event.total_cost_usd, 4)}"}</span>
+      </div>
+    </div>
+    """
+  end
+
+  def stream_event(%{event: %{type: :system}} = assigns) do
+    ~H"""
+    <div class="flex items-center gap-2 rounded-lg bg-base-200 border border-base-300 p-3 text-xs text-base-content/50">
+      <.icon name="hero-cog-6-tooth" class="size-4 shrink-0" />
+      <span>Session started</span>
+      <span :if={@event[:model]} class="font-mono">{@event.model}</span>
+    </div>
+    """
+  end
+
+  def stream_event(%{event: %{type: type}} = assigns) when type in [:error, :unknown] do
+    ~H"""
+    <div class="rounded-lg bg-base-300/50 p-3">
+      <pre class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono" phx-no-curly-interpolation><%= format_raw(@event) %></pre>
+    </div>
+    """
+  end
+
+  def stream_event(assigns) do
+    ~H"""
+    <div class="rounded-lg bg-base-300/50 p-3">
+      <pre class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono" phx-no-curly-interpolation><%= format_raw(@event) %></pre>
+    </div>
+    """
+  end
+
+  attr :block, :map, required: true
+
+  defp assistant_block(%{block: %{type: :text}} = assigns) do
+    ~H"""
+    <div class="flex gap-2.5 min-w-0">
+      <.icon name="hero-chat-bubble-left" class="size-4 shrink-0 mt-0.5 text-base-content/50" />
+      <div class="prose prose-sm prose-invert max-w-none text-base-content whitespace-pre-wrap break-words min-w-0">
+        {@block.text}
+      </div>
+    </div>
+    """
+  end
+
+  defp assistant_block(%{block: %{type: :tool_use}} = assigns) do
+    ~H"""
+    <div class="rounded-lg border border-base-300 bg-base-200 p-3 w-full">
+      <div class="flex items-center gap-2">
+        <.icon name="hero-wrench" class="size-4 shrink-0 text-info" />
+        <span class="font-mono text-sm font-semibold text-info">{@block.tool}</span>
+        <span class="text-xs text-base-content/40">calling tool</span>
+      </div>
+      <div :if={@block[:input] && @block.input != %{}} class="mt-2">
+        <pre class="text-xs text-base-content/50 whitespace-pre-wrap break-all font-mono bg-base-300/50 rounded p-2 overflow-x-auto" phx-no-curly-interpolation><%= format_json(@block.input) %></pre>
+      </div>
+    </div>
+    """
+  end
+
+  defp assistant_block(assigns) do
+    ~H"""
+    <div class="rounded-lg bg-base-300/50 p-2">
+      <pre class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono" phx-no-curly-interpolation><%= format_raw(@block) %></pre>
+    </div>
+    """
+  end
+
+  attr :result, :map, required: true
+
+  defp tool_result_block(%{result: %{type: :tool_result}} = assigns) do
+    ~H"""
+    <details class="rounded-lg border border-base-300 bg-base-200 group">
+      <summary class="flex items-center gap-2 p-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+        <.icon name="hero-chevron-right" class="size-3.5 shrink-0 text-base-content/40 transition-transform group-open:rotate-90" />
+        <.icon
+          name="hero-document-check"
+          class={if @result[:is_error], do: "size-4 shrink-0 text-error", else: "size-4 shrink-0 text-success"}
+        />
+        <span class="text-sm font-medium text-base-content/70">
+          {if @result[:is_error], do: "Error", else: "Result"}
+        </span>
+      </summary>
+      <div class="border-t border-base-300 p-3">
+        <pre class="text-xs text-base-content/60 whitespace-pre-wrap break-all font-mono max-h-96 overflow-y-auto" phx-no-curly-interpolation><%= format_tool_content(@result[:content]) %></pre>
+      </div>
+    </details>
+    """
+  end
+
+  defp tool_result_block(assigns) do
+    ~H"""
+    <div class="rounded-lg bg-base-300/50 p-2">
+      <pre class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono" phx-no-curly-interpolation><%= format_raw(@result) %></pre>
+    </div>
+    """
+  end
+
+  defp result_label(%{subtype: "success"}), do: "Completed successfully"
+  defp result_label(%{is_error: true}), do: "Completed with error"
+  defp result_label(%{stop_reason: reason}) when is_binary(reason), do: "Finished — #{reason}"
+  defp result_label(_), do: "Finished"
+
+  defp format_duration(ms) when is_number(ms) and ms >= 60_000 do
+    minutes = div(ms, 60_000)
+    seconds = div(rem(ms, 60_000), 1000)
+    "#{minutes}m #{seconds}s"
+  end
+
+  defp format_duration(ms) when is_number(ms) do
+    seconds = Float.round(ms / 1000, 1)
+    "#{seconds}s"
+  end
+
+  defp format_duration(_), do: ""
+
+  defp format_json(input) when is_map(input) do
+    case Jason.encode(input, pretty: true) do
+      {:ok, json} -> json
+      _ -> inspect(input)
+    end
+  end
+
+  defp format_json(input), do: inspect(input)
+
+  defp format_tool_content(content) when is_binary(content), do: content
+  defp format_tool_content(content) when is_list(content), do: Enum.join(content, "\n")
+  defp format_tool_content(content) when is_map(content), do: format_json(content)
+  defp format_tool_content(nil), do: "(no content)"
+  defp format_tool_content(content), do: inspect(content)
+
+  defp format_raw(%{raw: raw}) when is_binary(raw), do: raw
+  defp format_raw(%{raw: raw}) when is_map(raw), do: format_json(raw)
+  defp format_raw(data) when is_map(data), do: format_json(data)
+  defp format_raw(data), do: inspect(data)
+end

--- a/lib/citadel_web/components/agent_run_components.ex
+++ b/lib/citadel_web/components/agent_run_components.ex
@@ -34,7 +34,10 @@ defmodule CitadelWeb.AgentRunComponents do
           {result_label(@event)}
         </span>
       </div>
-      <div :if={@event[:duration_ms]} class="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-xs text-base-content/50">
+      <div
+        :if={@event[:duration_ms]}
+        class="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-xs text-base-content/50"
+      >
         <span>{format_duration(@event.duration_ms)}</span>
         <span :if={@event[:num_turns]}>{@event.num_turns} turns</span>
         <span :if={@event[:total_cost_usd]}>{"$#{Float.round(@event.total_cost_usd, 4)}"}</span>
@@ -56,7 +59,10 @@ defmodule CitadelWeb.AgentRunComponents do
   def stream_event(%{event: %{type: type}} = assigns) when type in [:error, :unknown] do
     ~H"""
     <div class="rounded-lg bg-base-300/50 p-3">
-      <pre class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono" phx-no-curly-interpolation><%= format_raw(@event) %></pre>
+      <pre
+        class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono"
+        phx-no-curly-interpolation
+      ><%= format_raw(@event) %></pre>
     </div>
     """
   end
@@ -64,7 +70,10 @@ defmodule CitadelWeb.AgentRunComponents do
   def stream_event(assigns) do
     ~H"""
     <div class="rounded-lg bg-base-300/50 p-3">
-      <pre class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono" phx-no-curly-interpolation><%= format_raw(@event) %></pre>
+      <pre
+        class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono"
+        phx-no-curly-interpolation
+      ><%= format_raw(@event) %></pre>
     </div>
     """
   end
@@ -91,7 +100,10 @@ defmodule CitadelWeb.AgentRunComponents do
         <span class="text-xs text-base-content/40">calling tool</span>
       </div>
       <div :if={@block[:input] && @block.input != %{}} class="mt-2">
-        <pre class="text-xs text-base-content/50 whitespace-pre-wrap break-all font-mono bg-base-300/50 rounded p-2 overflow-x-auto" phx-no-curly-interpolation><%= format_json(@block.input) %></pre>
+        <pre
+          class="text-xs text-base-content/50 whitespace-pre-wrap break-all font-mono bg-base-300/50 rounded p-2 overflow-x-auto"
+          phx-no-curly-interpolation
+        ><%= format_json(@block.input) %></pre>
       </div>
     </div>
     """
@@ -100,7 +112,10 @@ defmodule CitadelWeb.AgentRunComponents do
   defp assistant_block(assigns) do
     ~H"""
     <div class="rounded-lg bg-base-300/50 p-2">
-      <pre class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono" phx-no-curly-interpolation><%= format_raw(@block) %></pre>
+      <pre
+        class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono"
+        phx-no-curly-interpolation
+      ><%= format_raw(@block) %></pre>
     </div>
     """
   end
@@ -111,17 +126,27 @@ defmodule CitadelWeb.AgentRunComponents do
     ~H"""
     <details class="rounded-lg border border-base-300 bg-base-200 group">
       <summary class="flex items-center gap-2 p-3 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
-        <.icon name="hero-chevron-right" class="size-3.5 shrink-0 text-base-content/40 transition-transform group-open:rotate-90" />
+        <.icon
+          name="hero-chevron-right"
+          class="size-3.5 shrink-0 text-base-content/40 transition-transform group-open:rotate-90"
+        />
         <.icon
           name="hero-document-check"
-          class={if @result[:is_error], do: "size-4 shrink-0 text-error", else: "size-4 shrink-0 text-success"}
+          class={
+            if @result[:is_error],
+              do: "size-4 shrink-0 text-error",
+              else: "size-4 shrink-0 text-success"
+          }
         />
         <span class="text-sm font-medium text-base-content/70">
           {if @result[:is_error], do: "Error", else: "Result"}
         </span>
       </summary>
       <div class="border-t border-base-300 p-3">
-        <pre class="text-xs text-base-content/60 whitespace-pre-wrap break-all font-mono max-h-96 overflow-y-auto" phx-no-curly-interpolation><%= format_tool_content(@result[:content]) %></pre>
+        <pre
+          class="text-xs text-base-content/60 whitespace-pre-wrap break-all font-mono max-h-96 overflow-y-auto"
+          phx-no-curly-interpolation
+        ><%= format_tool_content(@result[:content]) %></pre>
       </div>
     </details>
     """
@@ -130,7 +155,10 @@ defmodule CitadelWeb.AgentRunComponents do
   defp tool_result_block(assigns) do
     ~H"""
     <div class="rounded-lg bg-base-300/50 p-2">
-      <pre class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono" phx-no-curly-interpolation><%= format_raw(@result) %></pre>
+      <pre
+        class="text-xs text-base-content/40 whitespace-pre-wrap break-all font-mono"
+        phx-no-curly-interpolation
+      ><%= format_raw(@result) %></pre>
     </div>
     """
   end

--- a/lib/citadel_web/live/agent_run_live.ex
+++ b/lib/citadel_web/live/agent_run_live.ex
@@ -74,6 +74,10 @@ defmodule CitadelWeb.AgentRunLive do
     {:noreply, assign(socket, :run, run)}
   end
 
+  defp process_event(%{parent_tool_use_id: parent_id}, socket)
+       when is_binary(parent_id),
+       do: socket
+
   defp process_event(%{type: :assistant, blocks: blocks} = event, socket) do
     {text_blocks, tool_blocks} = Enum.split_with(blocks, &(&1.type != :tool_use))
     {todo_blocks, visible_tool_blocks} = Enum.split_with(tool_blocks, &todo_tool?/1)
@@ -309,22 +313,40 @@ defmodule CitadelWeb.AgentRunLive do
             "shrink-0 mt-0.5 size-3.5 rounded border flex items-center justify-center",
             todo_status_classes(todo["status"])
           ]}>
-            <span :if={todo["status"] == "in_progress"} class="size-1.5 rounded-full bg-yellow-400 animate-pulse" />
+            <span
+              :if={todo["status"] == "in_progress"}
+              class="size-1.5 rounded-full bg-yellow-400 animate-pulse"
+            />
           </span>
           <span class={[
             "flex-1",
-            if(todo["status"] == "in_progress", do: "text-base-content/80", else: "text-base-content/50")
+            if(todo["status"] == "in_progress",
+              do: "text-base-content/80",
+              else: "text-base-content/50"
+            )
           ]}>
             {todo["content"]}
           </span>
-          <span :if={todo["priority"] == "high"} class="text-[9px] text-orange-400/70 uppercase shrink-0">
+          <span
+            :if={todo["priority"] == "high"}
+            class="text-[9px] text-orange-400/70 uppercase shrink-0"
+          >
             high
           </span>
         </li>
         <li :for={todo <- @completed} class="flex items-start gap-2 text-base-content/30">
           <span class="shrink-0 mt-0.5 size-3.5 rounded border border-emerald-500/30 bg-emerald-500/10 flex items-center justify-center text-emerald-400">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-2.5">
-              <path fill-rule="evenodd" d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z" clip-rule="evenodd" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              class="size-2.5"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z"
+                clip-rule="evenodd"
+              />
             </svg>
           </span>
           <span class="flex-1 line-through">{todo["content"]}</span>
@@ -344,7 +366,9 @@ defmodule CitadelWeb.AgentRunLive do
     ~H"""
     <div class="rounded-lg bg-blue-500/5 border border-blue-500/20 px-3 py-2">
       <div class="flex items-center gap-2 text-blue-400/70">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-blue-400/50">system</span>
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-blue-400/50">
+          system
+        </span>
         <span>{@subtype}</span>
         <span :if={@model} class="text-base-content/40 ml-auto">model={@model}</span>
       </div>
@@ -365,7 +389,9 @@ defmodule CitadelWeb.AgentRunLive do
         <div :for={block <- @blocks}>
           <%= case block.type do %>
             <% :text -> %>
-              <div class="prose prose-sm prose-invert max-w-none text-base-content/80">{to_markdown(block.text)}</div>
+              <div class="prose prose-sm prose-invert max-w-none text-base-content/80">
+                {to_markdown(block.text)}
+              </div>
             <% :thinking -> %>
               <div class="text-base-content/40 italic whitespace-pre-wrap">{block.text}</div>
             <% _ -> %>
@@ -463,7 +489,9 @@ defmodule CitadelWeb.AgentRunLive do
       <div class="text-[10px] font-semibold uppercase tracking-wider text-emerald-400/50 mb-1.5">
         tool result
       </div>
-      <div class={if(Map.get(@result, :is_error), do: "text-red-400/70", else: "text-base-content/50")}>
+      <div class={
+        if(Map.get(@result, :is_error), do: "text-red-400/70", else: "text-base-content/50")
+      }>
         {truncate_content(Map.get(@result, :content, @result[:raw] || @result))}
       </div>
     </div>
@@ -476,7 +504,9 @@ defmodule CitadelWeb.AgentRunLive do
     ~H"""
     <div class="rounded-lg bg-cyan-500/10 border border-cyan-500/20 px-3 py-2">
       <div class="flex items-center gap-2 text-cyan-400/70">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-cyan-400/50">result</span>
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-cyan-400/50">
+          result
+        </span>
         <span>{if @is_error, do: "error", else: @subtype}</span>
         <div class="ml-auto flex items-center gap-3 text-base-content/40">
           <span :if={@duration_ms}>
@@ -496,7 +526,9 @@ defmodule CitadelWeb.AgentRunLive do
 
     ~H"""
     <div class="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2">
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-red-400/50 mb-1">parse error</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-red-400/50 mb-1">
+        parse error
+      </div>
       <div class="text-base-content/40 break-all">{@raw}</div>
     </div>
     """
@@ -561,6 +593,8 @@ defmodule CitadelWeb.AgentRunLive do
   defp format_tool_detail(_tool, input) do
     Jason.encode!(input, pretty: true)
   end
+
+  defp truncate_content(nil), do: ""
 
   defp truncate_content(content) when is_binary(content) do
     if String.length(content) > 300 do

--- a/lib/citadel_web/live/agent_run_live.ex
+++ b/lib/citadel_web/live/agent_run_live.ex
@@ -3,6 +3,8 @@ defmodule CitadelWeb.AgentRunLive do
 
   use CitadelWeb, :live_view
 
+  import CitadelWeb.Components.Markdown
+
   alias Citadel.Agent.StreamParser
   alias Citadel.Tasks
 
@@ -21,6 +23,8 @@ defmodule CitadelWeb.AgentRunLive do
       socket
       |> assign(:run, run)
       |> assign(:page_title, "Agent Run")
+      |> assign(:pending_tools, %{})
+      |> assign(:todos, [])
       |> stream(:events, [])
 
     socket =
@@ -48,9 +52,7 @@ defmodule CitadelWeb.AgentRunLive do
         socket
       ) do
     parsed = StreamParser.parse(event_data)
-    id = "event-#{System.unique_integer([:positive])}"
-
-    {:noreply, stream_insert(socket, :events, %{id: id, parsed: parsed})}
+    {:noreply, process_event(parsed, socket)}
   end
 
   def handle_info(
@@ -71,6 +73,93 @@ defmodule CitadelWeb.AgentRunLive do
     run = reload_run(socket)
     {:noreply, assign(socket, :run, run)}
   end
+
+  defp process_event(%{type: :assistant, blocks: blocks} = event, socket) do
+    {text_blocks, tool_blocks} = Enum.split_with(blocks, &(&1.type != :tool_use))
+    {todo_blocks, visible_tool_blocks} = Enum.split_with(tool_blocks, &todo_tool?/1)
+
+    socket =
+      if text_blocks != [] do
+        id = "event-#{System.unique_integer([:positive])}"
+
+        stream_insert(socket, :events, %{
+          id: id,
+          parsed: %{type: :assistant_text, blocks: text_blocks, model: event[:model]}
+        })
+      else
+        socket
+      end
+
+    socket =
+      Enum.reduce(todo_blocks, socket, fn block, sock ->
+        pending = Map.put(sock.assigns.pending_tools, block.id, block)
+        sock = assign(sock, :pending_tools, pending)
+
+        case block do
+          %{tool: "TodoWrite", input: %{"todos" => todos}} when is_list(todos) ->
+            assign(sock, :todos, todos)
+
+          _ ->
+            sock
+        end
+      end)
+
+    Enum.reduce(visible_tool_blocks, socket, fn block, sock ->
+      tool_id = block.id
+      pending = Map.put(sock.assigns.pending_tools, tool_id, block)
+      sock = assign(sock, :pending_tools, pending)
+
+      stream_insert(sock, :events, %{
+        id: tool_id,
+        parsed: %{type: :tool_call, tool: block.tool, input: block.input, result: nil}
+      })
+    end)
+  end
+
+  defp process_event(%{type: :tool_result, results: results}, socket) do
+    Enum.reduce(results, socket, fn result, sock ->
+      tool_use_id = result[:tool_use_id]
+      pending = sock.assigns.pending_tools
+
+      if tool_use_id && Map.has_key?(pending, tool_use_id) do
+        tool = pending[tool_use_id]
+        sock = assign(sock, :pending_tools, Map.delete(pending, tool_use_id))
+
+        if todo_tool?(tool) do
+          sock
+        else
+          stream_insert(sock, :events, %{
+            id: tool_use_id,
+            parsed: %{type: :tool_call, tool: tool.tool, input: tool.input, result: result}
+          })
+        end
+      else
+        id = "event-#{System.unique_integer([:positive])}"
+
+        stream_insert(sock, :events, %{
+          id: id,
+          parsed: %{type: :tool_result_orphan, result: result}
+        })
+      end
+    end)
+  end
+
+  defp process_event(%{type: :system, subtype: "task_progress", tasks: tasks}, socket)
+       when is_list(tasks) do
+    assign(socket, :todos, tasks)
+  end
+
+  defp process_event(%{type: :system, subtype: "task_progress"}, socket), do: socket
+  defp process_event(%{type: :system, subtype: "task_started"}, socket), do: socket
+
+  defp process_event(parsed, socket) do
+    id = "event-#{System.unique_integer([:positive])}"
+    stream_insert(socket, :events, %{id: id, parsed: parsed})
+  end
+
+  defp todo_tool?(%{tool: "TodoWrite"}), do: true
+  defp todo_tool?(%{tool: "TodoRead"}), do: true
+  defp todo_tool?(_), do: false
 
   defp reload_run(socket) do
     Tasks.get_agent_run!(socket.assigns.run.id,
@@ -164,7 +253,10 @@ defmodule CitadelWeb.AgentRunLive do
               id="agent-run-events"
               phx-update="stream"
               phx-hook="AutoScroll"
-              class="flex-1 overflow-y-auto space-y-1 font-mono text-xs bg-base-300/30 rounded-lg p-3 max-h-[calc(100vh-20rem)]"
+              class={[
+                "flex-1 overflow-y-auto space-y-1 font-mono text-xs p-3",
+                if(@todos == [], do: "max-h-[calc(100vh-20rem)]", else: "max-h-[calc(100vh-32rem)]")
+              ]}
             >
               <div class="hidden only:block text-base-content/40 italic">
                 <%= if @run.status == :running do %>
@@ -174,9 +266,11 @@ defmodule CitadelWeb.AgentRunLive do
                 <% end %>
               </div>
               <div :for={{id, event} <- @streams.events} id={id}>
-                <.render_event event={event.parsed} />
+                <.render_event {event.parsed} />
               </div>
             </div>
+
+            <.todo_panel :if={@todos != []} todos={@todos} />
           </div>
         </div>
       </div>
@@ -184,66 +278,193 @@ defmodule CitadelWeb.AgentRunLive do
     """
   end
 
-  defp render_event(%{type: :system} = assigns) do
-    assigns = Map.put(assigns, :__changed__, nil)
+  defp todo_panel(assigns) do
+    {completed, remaining} = Enum.split_with(assigns.todos, &(&1["status"] == "completed"))
+    total = length(assigns.todos)
+    done = length(completed)
+    progress = if total > 0, do: round(done / total * 100), else: 0
+
+    assigns =
+      assigns
+      |> Map.put(:remaining, remaining)
+      |> Map.put(:completed, completed)
+      |> Map.put(:total, total)
+      |> Map.put(:done, done)
+      |> Map.put(:progress, progress)
 
     ~H"""
-    <div class="text-blue-400/70 py-0.5">
-      <span class="text-blue-400/50">[system]</span>
-      {@subtype}
-      <span :if={@model} class="text-base-content/40 ml-1">model={@model}</span>
+    <div class="border-t border-base-300 pt-3 mt-3 shrink-0">
+      <div class="flex items-center justify-between mb-2">
+        <h3 class="text-xs font-semibold text-base-content/70 uppercase tracking-wider">
+          Agent Progress
+        </h3>
+        <span class="text-xs text-base-content/50">{@done}/{@total}</span>
+      </div>
+
+      <progress class="progress progress-primary w-full h-1.5 mb-3" value={@progress} max="100" />
+
+      <ul class="space-y-1 text-xs max-h-40 overflow-y-auto">
+        <li :for={todo <- @remaining} class="flex items-start gap-2">
+          <span class={[
+            "shrink-0 mt-0.5 size-3.5 rounded border flex items-center justify-center",
+            todo_status_classes(todo["status"])
+          ]}>
+            <span :if={todo["status"] == "in_progress"} class="size-1.5 rounded-full bg-yellow-400 animate-pulse" />
+          </span>
+          <span class={[
+            "flex-1",
+            if(todo["status"] == "in_progress", do: "text-base-content/80", else: "text-base-content/50")
+          ]}>
+            {todo["content"]}
+          </span>
+          <span :if={todo["priority"] == "high"} class="text-[9px] text-orange-400/70 uppercase shrink-0">
+            high
+          </span>
+        </li>
+        <li :for={todo <- @completed} class="flex items-start gap-2 text-base-content/30">
+          <span class="shrink-0 mt-0.5 size-3.5 rounded border border-emerald-500/30 bg-emerald-500/10 flex items-center justify-center text-emerald-400">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-2.5">
+              <path fill-rule="evenodd" d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z" clip-rule="evenodd" />
+            </svg>
+          </span>
+          <span class="flex-1 line-through">{todo["content"]}</span>
+        </li>
+      </ul>
     </div>
     """
   end
 
-  defp render_event(%{type: :assistant, blocks: blocks} = assigns) do
-    assigns = assigns |> Map.put(:__changed__, nil) |> Map.put(:blocks, blocks)
+  defp todo_status_classes("in_progress"), do: "border-yellow-500/40 bg-yellow-500/10"
+  defp todo_status_classes("pending"), do: "border-base-content/20"
+  defp todo_status_classes(_), do: "border-base-content/20"
+
+  defp render_event(%{type: :system} = assigns) do
+    assigns = Map.put(assigns, :__changed__, nil)
 
     ~H"""
-    <div class="py-0.5">
-      <div :for={block <- @blocks}>
-        <%= cond do %>
-          <% block.type == :text -> %>
-            <div class="text-base-content/80 whitespace-pre-wrap">{block.text}</div>
-          <% block.type == :tool_use -> %>
-            <div class="text-purple-400/80">
-              <span class="text-purple-400/50">[tool]</span>
-              {block.tool}
-              <span :if={block.input != %{}} class="text-base-content/40 ml-1">
-                {Jason.encode!(block.input) |> String.slice(0, 200)}
-              </span>
-            </div>
-          <% true -> %>
-            <div class="text-base-content/40">{inspect(block)}</div>
-        <% end %>
+    <div class="rounded-lg bg-blue-500/5 border border-blue-500/20 px-3 py-2">
+      <div class="flex items-center gap-2 text-blue-400/70">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-blue-400/50">system</span>
+        <span>{@subtype}</span>
+        <span :if={@model} class="text-base-content/40 ml-auto">model={@model}</span>
       </div>
     </div>
     """
   end
 
-  defp render_event(%{type: :tool_result, results: results} = assigns) do
-    assigns = assigns |> Map.put(:__changed__, nil) |> Map.put(:results, results)
+  defp render_event(%{type: :assistant_text} = assigns) do
+    assigns = Map.put(assigns, :__changed__, nil)
 
     ~H"""
-    <div class="py-0.5">
-      <div :for={result <- @results}>
-        <%= if result.type == :tool_result do %>
-          <div class={[
-            "text-sm",
-            if(result.is_error, do: "text-red-400/80", else: "text-emerald-400/70")
-          ]}>
-            <span class={[
-              if(result.is_error, do: "text-red-400/50", else: "text-emerald-400/50")
-            ]}>
-              [{if result.is_error, do: "error", else: "result"}]
-            </span>
-            <span class="text-base-content/40 ml-1 truncate inline-block max-w-full align-bottom">
-              {truncate_content(result.content)}
-            </span>
-          </div>
-        <% else %>
-          <div class="text-base-content/40">{inspect(result)}</div>
-        <% end %>
+    <div class="rounded-lg bg-base-300/40 border border-base-300 px-3 py-2">
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-base-content/40 mb-1.5">
+        assistant
+        <span :if={@model} class="font-normal normal-case tracking-normal ml-1">{@model}</span>
+      </div>
+      <div class="space-y-1">
+        <div :for={block <- @blocks}>
+          <%= case block.type do %>
+            <% :text -> %>
+              <div class="prose prose-sm prose-invert max-w-none text-base-content/80">{to_markdown(block.text)}</div>
+            <% :thinking -> %>
+              <div class="text-base-content/40 italic whitespace-pre-wrap">{block.text}</div>
+            <% _ -> %>
+              <div class="text-base-content/40">{inspect(block)}</div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event(%{type: :tool_call, result: nil} = assigns) do
+    assigns = Map.put(assigns, :__changed__, nil)
+
+    ~H"""
+    <details class="group">
+      <summary class="flex items-center gap-2 cursor-pointer list-none py-1.5 [&::-webkit-details-marker]:hidden">
+        <span class="shrink-0 inline-block size-1.5 rounded-full bg-yellow-400 animate-pulse" />
+        <span class="font-semibold text-purple-400/80">{@tool}</span>
+        <span :if={format_tool_description(@tool, @input)} class="text-base-content/50 truncate">
+          {format_tool_description(@tool, @input)}
+        </span>
+        <svg
+          class="shrink-0 ml-auto size-3 text-base-content/30 transition-transform group-open:rotate-180"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </summary>
+      <div :if={@input != %{}} class="pl-5 text-base-content/40 break-all">
+        <pre class="whitespace-pre-wrap text-xs">{format_tool_detail(@tool, @input)}</pre>
+      </div>
+    </details>
+    """
+  end
+
+  defp render_event(%{type: :tool_call, result: result} = assigns) do
+    assigns = assigns |> Map.put(:__changed__, nil) |> Map.put(:result, result)
+
+    ~H"""
+    <details class="group">
+      <summary class="flex items-center gap-2 cursor-pointer list-none py-1.5 [&::-webkit-details-marker]:hidden">
+        <span class="font-semibold text-purple-400/80">{@tool}</span>
+        <span :if={format_tool_description(@tool, @input)} class="text-base-content/50 truncate">
+          {format_tool_description(@tool, @input)}
+        </span>
+        <span
+          :if={@result.is_error}
+          class="shrink-0 inline-block rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-red-400"
+        >
+          error
+        </span>
+        <svg
+          class="shrink-0 ml-auto size-3 text-base-content/30 transition-transform group-open:rotate-180"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </summary>
+      <div class="pl-5">
+        <div :if={@input != %{}} class="text-base-content/40 break-all">
+          <pre class="whitespace-pre-wrap text-xs">{format_tool_detail(@tool, @input)}</pre>
+        </div>
+        <div class={[
+          "mt-1 pt-1 border-t break-all",
+          if(@result.is_error,
+            do: "border-red-500/20 text-red-400/70",
+            else: "border-base-300/50 text-base-content/50"
+          )
+        ]}>
+          {truncate_content(@result.content)}
+        </div>
+      </div>
+    </details>
+    """
+  end
+
+  defp render_event(%{type: :tool_result_orphan} = assigns) do
+    assigns = Map.put(assigns, :__changed__, nil)
+
+    ~H"""
+    <div class="rounded-lg bg-emerald-500/5 border border-emerald-500/20 px-3 py-2">
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-emerald-400/50 mb-1.5">
+        tool result
+      </div>
+      <div class={if(Map.get(@result, :is_error), do: "text-red-400/70", else: "text-base-content/50")}>
+        {truncate_content(Map.get(@result, :content, @result[:raw] || @result))}
       </div>
     </div>
     """
@@ -253,15 +474,19 @@ defmodule CitadelWeb.AgentRunLive do
     assigns = Map.put(assigns, :__changed__, nil)
 
     ~H"""
-    <div class="text-cyan-400/70 py-1 border-t border-base-300/50 mt-1">
-      <span class="text-cyan-400/50">[result]</span>
-      {if @is_error, do: "error", else: @subtype}
-      <span :if={@duration_ms} class="text-base-content/40 ml-2">
-        {(@duration_ms / 1000) |> Float.round(1)}s
-      </span>
-      <span :if={@total_cost_usd} class="text-base-content/40 ml-2">
-        ${Float.round(@total_cost_usd, 4)}
-      </span>
+    <div class="rounded-lg bg-cyan-500/10 border border-cyan-500/20 px-3 py-2">
+      <div class="flex items-center gap-2 text-cyan-400/70">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-cyan-400/50">result</span>
+        <span>{if @is_error, do: "error", else: @subtype}</span>
+        <div class="ml-auto flex items-center gap-3 text-base-content/40">
+          <span :if={@duration_ms}>
+            {(@duration_ms / 1000) |> Float.round(1)}s
+          </span>
+          <span :if={@total_cost_usd}>
+            ${Float.round(@total_cost_usd, 4)}
+          </span>
+        </div>
+      </div>
     </div>
     """
   end
@@ -270,9 +495,9 @@ defmodule CitadelWeb.AgentRunLive do
     assigns = Map.put(assigns, :__changed__, nil)
 
     ~H"""
-    <div class="text-red-400/70 py-0.5">
-      <span class="text-red-400/50">[parse error]</span>
-      <span class="text-base-content/40">{@raw}</span>
+    <div class="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2">
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-red-400/50 mb-1">parse error</div>
+      <div class="text-base-content/40 break-all">{@raw}</div>
     </div>
     """
   end
@@ -281,8 +506,60 @@ defmodule CitadelWeb.AgentRunLive do
     assigns = Map.put(assigns, :__changed__, nil)
 
     ~H"""
-    <div class="text-base-content/40 py-0.5">{inspect(assigns |> Map.drop([:__changed__]))}</div>
+    <div class="rounded-lg bg-base-300/30 border border-base-300 px-3 py-2">
+      <div class="text-base-content/40 break-all">{inspect(assigns |> Map.drop([:__changed__]))}</div>
+    </div>
     """
+  end
+
+  defp format_tool_description("Bash", %{"description" => desc}) when is_binary(desc), do: desc
+  defp format_tool_description("Bash", %{"command" => cmd}), do: String.slice(cmd, 0, 80)
+  defp format_tool_description("Read", %{"file_path" => path}), do: path
+  defp format_tool_description("Write", %{"file_path" => path}), do: path
+  defp format_tool_description("Edit", %{"file_path" => path}), do: path
+  defp format_tool_description("Glob", %{"pattern" => pattern}), do: pattern
+
+  defp format_tool_description("Grep", %{"pattern" => pattern} = input) do
+    path = input["path"]
+    if path, do: "#{pattern} in #{path}", else: pattern
+  end
+
+  defp format_tool_description("Agent", %{"prompt" => prompt} = input) do
+    type = input["subagent_type"]
+    prefix = if type, do: "[#{type}] ", else: ""
+    "#{prefix}#{String.slice(prompt, 0, 100)}"
+  end
+
+  defp format_tool_description(_tool, _input), do: nil
+
+  defp format_tool_detail("Bash", %{"command" => cmd}), do: "$ #{cmd}"
+  defp format_tool_detail("Read", %{"file_path" => path}), do: path
+
+  defp format_tool_detail("Edit", %{"file_path" => path} = input) do
+    old = input["old_string"]
+    new = input["new_string"]
+
+    parts = [path]
+    parts = if old, do: parts ++ ["\n--- old\n#{old}"], else: parts
+    parts = if new, do: parts ++ ["\n+++ new\n#{new}"], else: parts
+    Enum.join(parts)
+  end
+
+  defp format_tool_detail("Write", %{"file_path" => path}), do: path
+
+  defp format_tool_detail("Grep", %{"pattern" => pattern} = input) do
+    path = input["path"]
+    if path, do: "#{pattern} in #{path}", else: pattern
+  end
+
+  defp format_tool_detail("Agent", %{"prompt" => prompt} = input) do
+    type = input["subagent_type"]
+    prefix = if type, do: "[#{type}] ", else: ""
+    "#{prefix}#{prompt}"
+  end
+
+  defp format_tool_detail(_tool, input) do
+    Jason.encode!(input, pretty: true)
   end
 
   defp truncate_content(content) when is_binary(content) do

--- a/lib/citadel_web/live/agent_run_live.ex
+++ b/lib/citadel_web/live/agent_run_live.ex
@@ -126,17 +126,7 @@ defmodule CitadelWeb.AgentRunLive do
       pending = sock.assigns.pending_tools
 
       if tool_use_id && Map.has_key?(pending, tool_use_id) do
-        tool = pending[tool_use_id]
-        sock = assign(sock, :pending_tools, Map.delete(pending, tool_use_id))
-
-        if todo_tool?(tool) do
-          sock
-        else
-          stream_insert(sock, :events, %{
-            id: tool_use_id,
-            parsed: %{type: :tool_call, tool: tool.tool, input: tool.input, result: result}
-          })
-        end
+        process_matched_tool_result(sock, pending, tool_use_id, result)
       else
         id = "event-#{System.unique_integer([:positive])}"
 
@@ -159,6 +149,20 @@ defmodule CitadelWeb.AgentRunLive do
   defp process_event(parsed, socket) do
     id = "event-#{System.unique_integer([:positive])}"
     stream_insert(socket, :events, %{id: id, parsed: parsed})
+  end
+
+  defp process_matched_tool_result(sock, pending, tool_use_id, result) do
+    tool = pending[tool_use_id]
+    sock = assign(sock, :pending_tools, Map.delete(pending, tool_use_id))
+
+    if todo_tool?(tool) do
+      sock
+    else
+      stream_insert(sock, :events, %{
+        id: tool_use_id,
+        parsed: %{type: :tool_call, tool: tool.tool, input: tool.input, result: result}
+      })
+    end
   end
 
   defp todo_tool?(%{tool: "TodoWrite"}), do: true

--- a/lib/citadel_web/live/agent_run_live.ex
+++ b/lib/citadel_web/live/agent_run_live.ex
@@ -1,0 +1,306 @@
+defmodule CitadelWeb.AgentRunLive do
+  @moduledoc false
+
+  use CitadelWeb, :live_view
+
+  alias Citadel.Agent.StreamParser
+  alias Citadel.Tasks
+
+  def mount(%{"id" => id}, _session, socket) do
+    user = socket.assigns.current_user
+    workspace = socket.assigns.current_workspace
+
+    run =
+      Tasks.get_agent_run!(id,
+        actor: user,
+        tenant: workspace.id,
+        load: [:task]
+      )
+
+    socket =
+      socket
+      |> assign(:run, run)
+      |> assign(:page_title, "Agent Run")
+      |> stream(:events, [])
+
+    socket =
+      if connected?(socket) do
+        CitadelWeb.Endpoint.subscribe("tasks:agent_runs:#{run.task_id}")
+
+        if run.status == :running do
+          CitadelWeb.Endpoint.subscribe("agent_run_output:#{run.id}")
+        end
+
+        socket
+      else
+        socket
+      end
+
+    {:ok, socket}
+  end
+
+  def handle_info(
+        %Phoenix.Socket.Broadcast{
+          topic: "agent_run_output:" <> _,
+          event: "stream_event",
+          payload: %{event: event_data}
+        },
+        socket
+      ) do
+    parsed = StreamParser.parse(event_data)
+    id = "event-#{System.unique_integer([:positive])}"
+
+    {:noreply, stream_insert(socket, :events, %{id: id, parsed: parsed})}
+  end
+
+  def handle_info(
+        %Phoenix.Socket.Broadcast{
+          topic: "agent_run_output:" <> _,
+          event: "stream_complete"
+        },
+        socket
+      ) do
+    run = reload_run(socket)
+    {:noreply, assign(socket, :run, run)}
+  end
+
+  def handle_info(
+        %Phoenix.Socket.Broadcast{topic: "tasks:agent_runs:" <> _},
+        socket
+      ) do
+    run = reload_run(socket)
+    {:noreply, assign(socket, :run, run)}
+  end
+
+  defp reload_run(socket) do
+    Tasks.get_agent_run!(socket.assigns.run.id,
+      actor: socket.assigns.current_user,
+      tenant: socket.assigns.current_workspace.id,
+      load: [:task]
+    )
+  end
+
+  defp status_classes(:pending), do: "bg-base-300/50 text-base-content/60"
+  defp status_classes(:running), do: "bg-yellow-500/15 text-yellow-400"
+  defp status_classes(:completed), do: "bg-emerald-500/15 text-emerald-400"
+  defp status_classes(:failed), do: "bg-red-500/15 text-red-400"
+  defp status_classes(:cancelled), do: "bg-orange-500/15 text-orange-400"
+  defp status_classes(_), do: "bg-base-300/50 text-base-content/60"
+
+  defp dot_class(:pending), do: "bg-base-content/40"
+  defp dot_class(:running), do: "bg-yellow-400 animate-pulse"
+  defp dot_class(:completed), do: "bg-emerald-400"
+  defp dot_class(:failed), do: "bg-red-400"
+  defp dot_class(:cancelled), do: "bg-orange-400"
+  defp dot_class(_), do: "bg-base-content/40"
+
+  defp format_timestamp(nil), do: nil
+
+  defp format_timestamp(dt) do
+    Calendar.strftime(dt, "%b %d, %Y %H:%M:%S")
+  end
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.app
+      flash={@flash}
+      current_workspace={@current_workspace}
+      workspaces={@workspaces}
+      agents={@agents}
+    >
+      <div class="relative h-full p-4 bg-base-200 border border-base-300">
+        <div class="h-full overflow-auto flex flex-col">
+          <div class="breadcrumbs text-sm mb-4">
+            <ul>
+              <li><.link navigate={~p"/dashboard"}>Tasks</.link></li>
+              <li>
+                <.link navigate={~p"/tasks/#{@run.task.human_id}"}>{@run.task.human_id}</.link>
+              </li>
+              <li><span>Agent Run</span></li>
+            </ul>
+          </div>
+
+          <div class="flex items-center justify-between mb-4">
+            <div class="flex items-center gap-3">
+              <h1 class="text-xl font-bold">Agent Run</h1>
+              <span class={[
+                "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
+                status_classes(@run.status)
+              ]}>
+                <span class={["size-1.5 rounded-full", dot_class(@run.status)]} />
+                {@run.status}
+              </span>
+            </div>
+          </div>
+
+          <div class="flex flex-wrap gap-x-6 gap-y-1 text-sm text-base-content/60 mb-4">
+            <div class="flex items-center gap-1.5">
+              <span class="font-medium">Task:</span>
+              <.link
+                navigate={~p"/tasks/#{@run.task.human_id}"}
+                class="text-primary hover:underline"
+              >
+                {@run.task.human_id} — {@run.task.title}
+              </.link>
+            </div>
+            <div :if={@run.started_at} class="flex items-center gap-1.5">
+              <span class="font-medium">Started:</span>
+              <span>{format_timestamp(@run.started_at)}</span>
+            </div>
+            <div :if={@run.completed_at} class="flex items-center gap-1.5">
+              <span class="font-medium">Completed:</span>
+              <span>{format_timestamp(@run.completed_at)}</span>
+            </div>
+            <div :if={@run.error_message} class="flex items-center gap-1.5">
+              <span class="font-medium text-error">Error:</span>
+              <span class="text-error">{@run.error_message}</span>
+            </div>
+          </div>
+
+          <div class="border-t border-base-300 pt-4 flex-1 min-h-0 flex flex-col">
+            <h2 class="text-sm font-semibold text-base-content/70 mb-3">Stream Output</h2>
+
+            <div
+              id="agent-run-events"
+              phx-update="stream"
+              phx-hook="AutoScroll"
+              class="flex-1 overflow-y-auto space-y-1 font-mono text-xs bg-base-300/30 rounded-lg p-3 max-h-[calc(100vh-20rem)]"
+            >
+              <div class="hidden only:block text-base-content/40 italic">
+                <%= if @run.status == :running do %>
+                  Waiting for events...
+                <% else %>
+                  No stream events captured for this run.
+                <% end %>
+              </div>
+              <div :for={{id, event} <- @streams.events} id={id}>
+                <.render_event event={event.parsed} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  defp render_event(%{type: :system} = assigns) do
+    assigns = Map.put(assigns, :__changed__, nil)
+
+    ~H"""
+    <div class="text-blue-400/70 py-0.5">
+      <span class="text-blue-400/50">[system]</span>
+      {@subtype}
+      <span :if={@model} class="text-base-content/40 ml-1">model={@model}</span>
+    </div>
+    """
+  end
+
+  defp render_event(%{type: :assistant, blocks: blocks} = assigns) do
+    assigns = assigns |> Map.put(:__changed__, nil) |> Map.put(:blocks, blocks)
+
+    ~H"""
+    <div class="py-0.5">
+      <div :for={block <- @blocks}>
+        <%= cond do %>
+          <% block.type == :text -> %>
+            <div class="text-base-content/80 whitespace-pre-wrap">{block.text}</div>
+          <% block.type == :tool_use -> %>
+            <div class="text-purple-400/80">
+              <span class="text-purple-400/50">[tool]</span>
+              {block.tool}
+              <span :if={block.input != %{}} class="text-base-content/40 ml-1">
+                {Jason.encode!(block.input) |> String.slice(0, 200)}
+              </span>
+            </div>
+          <% true -> %>
+            <div class="text-base-content/40">{inspect(block)}</div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event(%{type: :tool_result, results: results} = assigns) do
+    assigns = assigns |> Map.put(:__changed__, nil) |> Map.put(:results, results)
+
+    ~H"""
+    <div class="py-0.5">
+      <div :for={result <- @results}>
+        <%= if result.type == :tool_result do %>
+          <div class={[
+            "text-sm",
+            if(result.is_error, do: "text-red-400/80", else: "text-emerald-400/70")
+          ]}>
+            <span class={[
+              if(result.is_error, do: "text-red-400/50", else: "text-emerald-400/50")
+            ]}>
+              [{if result.is_error, do: "error", else: "result"}]
+            </span>
+            <span class="text-base-content/40 ml-1 truncate inline-block max-w-full align-bottom">
+              {truncate_content(result.content)}
+            </span>
+          </div>
+        <% else %>
+          <div class="text-base-content/40">{inspect(result)}</div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_event(%{type: :result} = assigns) do
+    assigns = Map.put(assigns, :__changed__, nil)
+
+    ~H"""
+    <div class="text-cyan-400/70 py-1 border-t border-base-300/50 mt-1">
+      <span class="text-cyan-400/50">[result]</span>
+      {if @is_error, do: "error", else: @subtype}
+      <span :if={@duration_ms} class="text-base-content/40 ml-2">
+        {(@duration_ms / 1000) |> Float.round(1)}s
+      </span>
+      <span :if={@total_cost_usd} class="text-base-content/40 ml-2">
+        ${Float.round(@total_cost_usd, 4)}
+      </span>
+    </div>
+    """
+  end
+
+  defp render_event(%{type: :error} = assigns) do
+    assigns = Map.put(assigns, :__changed__, nil)
+
+    ~H"""
+    <div class="text-red-400/70 py-0.5">
+      <span class="text-red-400/50">[parse error]</span>
+      <span class="text-base-content/40">{@raw}</span>
+    </div>
+    """
+  end
+
+  defp render_event(assigns) do
+    assigns = Map.put(assigns, :__changed__, nil)
+
+    ~H"""
+    <div class="text-base-content/40 py-0.5">{inspect(assigns |> Map.drop([:__changed__]))}</div>
+    """
+  end
+
+  defp truncate_content(content) when is_binary(content) do
+    if String.length(content) > 300 do
+      String.slice(content, 0, 300) <> "..."
+    else
+      content
+    end
+  end
+
+  defp truncate_content(content) when is_list(content) do
+    content
+    |> Enum.map_join(" ", fn
+      %{"type" => "text", "text" => text} -> text
+      other -> inspect(other)
+    end)
+    |> truncate_content()
+  end
+
+  defp truncate_content(content), do: inspect(content)
+end

--- a/lib/citadel_web/live/task_live/show.ex
+++ b/lib/citadel_web/live/task_live/show.ex
@@ -917,6 +917,13 @@ defmodule CitadelWeb.TaskLive.Show do
                       <span :if={run.error_message} class="text-xs text-error">
                         {run.error_message}
                       </span>
+                      <.link
+                        :if={run.status == :running}
+                        navigate={~p"/agent-runs/#{run.id}"}
+                        class="btn btn-xs btn-ghost text-info hover:bg-info/10"
+                      >
+                        <.icon name="hero-eye" class="size-3.5" /> Watch
+                      </.link>
                       <button
                         :if={@can_edit and run.status in [:pending, :running]}
                         phx-click="confirm_cancel_run"

--- a/lib/citadel_web/router.ex
+++ b/lib/citadel_web/router.ex
@@ -76,6 +76,7 @@ defmodule CitadelWeb.Router do
       live "/preferences/workspaces/:id/edit", PreferencesLive.WorkspaceForm, :edit
       live "/preferences/workspace/:id", PreferencesLive.Workspace, :show
       live "/preferences/api-keys/new", PreferencesLive.ApiKeyNew, :new
+      live "/agent-runs/:id", AgentRunLive
       # in each liveview, add one of the following at the top of the module:
       #
       # If an authenticated user must be present:

--- a/test/citadel/agent/stream_parser_test.exs
+++ b/test/citadel/agent/stream_parser_test.exs
@@ -1,0 +1,223 @@
+defmodule Citadel.Agent.StreamParserTest do
+  use ExUnit.Case, async: true
+
+  alias Citadel.Agent.StreamParser
+
+  describe "parse/1" do
+    test "parses system init event" do
+      json =
+        Jason.encode!(%{
+          "type" => "system",
+          "subtype" => "init",
+          "cwd" => "/some/path",
+          "session_id" => "abc-123",
+          "tools" => ["Bash", "Read", "Write"],
+          "model" => "claude-opus-4-6[1m]"
+        })
+
+      assert %{
+               type: :system,
+               subtype: "init",
+               session_id: "abc-123",
+               tools: ["Bash", "Read", "Write"],
+               model: "claude-opus-4-6[1m]"
+             } = StreamParser.parse(json)
+    end
+
+    test "parses assistant event with text content" do
+      json =
+        Jason.encode!(%{
+          "type" => "assistant",
+          "message" => %{
+            "model" => "claude-opus-4-6",
+            "content" => [
+              %{"type" => "text", "text" => "Hello! How can I help you today?"}
+            ]
+          },
+          "session_id" => "abc-123"
+        })
+
+      assert %{
+               type: :assistant,
+               blocks: [%{type: :text, text: "Hello! How can I help you today?"}],
+               model: "claude-opus-4-6",
+               session_id: "abc-123"
+             } = StreamParser.parse(json)
+    end
+
+    test "parses assistant event with tool_use content" do
+      json =
+        Jason.encode!(%{
+          "type" => "assistant",
+          "message" => %{
+            "model" => "claude-opus-4-6",
+            "content" => [
+              %{
+                "type" => "tool_use",
+                "id" => "toolu_abc123",
+                "name" => "Bash",
+                "input" => %{"command" => "echo hello", "description" => "Print hello"}
+              }
+            ]
+          },
+          "session_id" => "abc-123"
+        })
+
+      assert %{
+               type: :assistant,
+               blocks: [
+                 %{
+                   type: :tool_use,
+                   tool: "Bash",
+                   input: %{"command" => "echo hello", "description" => "Print hello"},
+                   id: "toolu_abc123"
+                 }
+               ]
+             } = StreamParser.parse(json)
+    end
+
+    test "parses assistant event with mixed text and tool_use blocks" do
+      json =
+        Jason.encode!(%{
+          "type" => "assistant",
+          "message" => %{
+            "model" => "claude-opus-4-6",
+            "content" => [
+              %{"type" => "text", "text" => "Let me check that."},
+              %{
+                "type" => "tool_use",
+                "id" => "toolu_xyz",
+                "name" => "Read",
+                "input" => %{"file_path" => "/tmp/test.txt"}
+              }
+            ]
+          },
+          "session_id" => "abc-123"
+        })
+
+      result = StreamParser.parse(json)
+      assert result.type == :assistant
+      assert length(result.blocks) == 2
+      assert Enum.at(result.blocks, 0).type == :text
+      assert Enum.at(result.blocks, 1).type == :tool_use
+      assert Enum.at(result.blocks, 1).tool == "Read"
+    end
+
+    test "parses user/tool_result event" do
+      json =
+        Jason.encode!(%{
+          "type" => "user",
+          "message" => %{
+            "role" => "user",
+            "content" => [
+              %{
+                "tool_use_id" => "toolu_abc123",
+                "type" => "tool_result",
+                "content" => "hello",
+                "is_error" => false
+              }
+            ]
+          },
+          "session_id" => "abc-123",
+          "tool_use_result" => %{
+            "stdout" => "hello",
+            "stderr" => "",
+            "interrupted" => false
+          }
+        })
+
+      assert %{
+               type: :tool_result,
+               results: [
+                 %{
+                   type: :tool_result,
+                   tool_use_id: "toolu_abc123",
+                   content: "hello",
+                   is_error: false
+                 }
+               ],
+               session_id: "abc-123",
+               tool_use_result: %{"stdout" => "hello", "stderr" => "", "interrupted" => false}
+             } = StreamParser.parse(json)
+    end
+
+    test "parses result event (success)" do
+      json =
+        Jason.encode!(%{
+          "type" => "result",
+          "subtype" => "success",
+          "is_error" => false,
+          "duration_ms" => 2109,
+          "num_turns" => 1,
+          "result" => "Hello! How can I help you today?",
+          "stop_reason" => "end_turn",
+          "session_id" => "abc-123",
+          "total_cost_usd" => 0.047,
+          "usage" => %{"input_tokens" => 3, "output_tokens" => 12}
+        })
+
+      assert %{
+               type: :result,
+               subtype: "success",
+               is_error: false,
+               result: "Hello! How can I help you today?",
+               stop_reason: "end_turn",
+               duration_ms: 2109,
+               num_turns: 1,
+               total_cost_usd: 0.047,
+               session_id: "abc-123"
+             } = StreamParser.parse(json)
+    end
+
+    test "parses result event (error)" do
+      json =
+        Jason.encode!(%{
+          "type" => "result",
+          "subtype" => "error",
+          "is_error" => true,
+          "result" => "Something went wrong",
+          "stop_reason" => "error",
+          "session_id" => "abc-123"
+        })
+
+      result = StreamParser.parse(json)
+      assert result.type == :result
+      assert result.subtype == "error"
+      assert result.is_error == true
+    end
+
+    test "parses rate_limit_event" do
+      json =
+        Jason.encode!(%{
+          "type" => "rate_limit_event",
+          "rate_limit_info" => %{
+            "status" => "allowed",
+            "resetsAt" => 1_773_460_800,
+            "rateLimitType" => "five_hour"
+          },
+          "session_id" => "abc-123"
+        })
+
+      assert %{
+               type: :rate_limit_event,
+               rate_limit_info: %{"status" => "allowed"},
+               session_id: "abc-123"
+             } = StreamParser.parse(json)
+    end
+
+    test "returns unknown for unrecognized event types" do
+      json = Jason.encode!(%{"type" => "some_future_event", "data" => "value"})
+
+      assert %{type: :unknown, raw: %{"type" => "some_future_event", "data" => "value"}} =
+               StreamParser.parse(json)
+    end
+
+    test "returns error for invalid JSON" do
+      assert %{type: :error, raw: "not valid json {"} = StreamParser.parse("not valid json {")
+    end
+
+    test "returns error for empty string" do
+      assert %{type: :error, raw: ""} = StreamParser.parse("")
+    end
+  end
+end

--- a/test/citadel/agent/stream_parser_test.exs
+++ b/test/citadel/agent/stream_parser_test.exs
@@ -219,5 +219,85 @@ defmodule Citadel.Agent.StreamParserTest do
     test "returns error for empty string" do
       assert %{type: :error, raw: ""} = StreamParser.parse("")
     end
+
+    test "extracts parent_tool_use_id for assistant events" do
+      json =
+        Jason.encode!(%{
+          "type" => "assistant",
+          "parent_tool_use_id" => "toolu_parent_abc",
+          "message" => %{
+            "model" => "claude-opus-4-6",
+            "content" => [
+              %{"type" => "text", "text" => "Sub-agent working..."}
+            ]
+          },
+          "session_id" => "sub-session"
+        })
+
+      result = StreamParser.parse(json)
+      assert result.type == :assistant
+      assert result.parent_tool_use_id == "toolu_parent_abc"
+    end
+
+    test "extracts parent_tool_use_id for tool_result events" do
+      json =
+        Jason.encode!(%{
+          "type" => "user",
+          "parent_tool_use_id" => "toolu_parent_xyz",
+          "message" => %{
+            "role" => "user",
+            "content" => [
+              %{
+                "tool_use_id" => "toolu_sub_123",
+                "type" => "tool_result",
+                "content" => "result data"
+              }
+            ]
+          },
+          "session_id" => "sub-session"
+        })
+
+      result = StreamParser.parse(json)
+      assert result.type == :tool_result
+      assert result.parent_tool_use_id == "toolu_parent_xyz"
+    end
+
+    test "parent_tool_use_id is nil for top-level events" do
+      json =
+        Jason.encode!(%{
+          "type" => "assistant",
+          "message" => %{
+            "model" => "claude-opus-4-6",
+            "content" => [
+              %{"type" => "text", "text" => "Hello"}
+            ]
+          },
+          "session_id" => "abc-123"
+        })
+
+      result = StreamParser.parse(json)
+      assert result.parent_tool_use_id == nil
+    end
+
+    test "tool_result block without content field preserves tool_use_id" do
+      json =
+        Jason.encode!(%{
+          "type" => "user",
+          "message" => %{
+            "role" => "user",
+            "content" => [
+              %{
+                "tool_use_id" => "toolu_no_content",
+                "type" => "tool_result"
+              }
+            ]
+          },
+          "session_id" => "abc-123"
+        })
+
+      result = StreamParser.parse(json)
+      assert result.type == :tool_result
+      assert [%{tool_use_id: "toolu_no_content", content: nil}] = result.results
+    end
   end
 end

--- a/test/citadel_web/channels/agent_channel_test.exs
+++ b/test/citadel_web/channels/agent_channel_test.exs
@@ -1,0 +1,90 @@
+defmodule CitadelWeb.AgentChannelTest do
+  use CitadelWeb.ChannelCase, async: true
+
+  alias CitadelWeb.AgentChannel
+
+  setup do
+    workspace_id = Ash.UUID.generate()
+    agent_name = "test-agent-#{System.unique_integer([:positive])}"
+
+    {:ok, _, socket} =
+      CitadelWeb.AgentSocket
+      |> socket("agent_socket:#{workspace_id}", %{workspace_id: workspace_id})
+      |> subscribe_and_join(AgentChannel, "agents:#{workspace_id}", %{
+        "agent_name" => agent_name
+      })
+
+    %{socket: socket, workspace_id: workspace_id}
+  end
+
+  describe "stream_output" do
+    test "broadcasts event data to the run's PubSub topic", %{socket: socket} do
+      run_id = Ash.UUID.generate()
+      topic = "agent_run_output:#{run_id}"
+      CitadelWeb.Endpoint.subscribe(topic)
+
+      event_data = %{"type" => "assistant", "content" => "Hello"}
+      push(socket, "stream_output", %{"run_id" => run_id, "event" => event_data})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: ^topic,
+        event: "stream_event",
+        payload: %{event: ^event_data}
+      }
+    end
+
+    test "handles missing run_id gracefully", %{socket: socket} do
+      import ExUnit.CaptureLog
+
+      capture_log(fn ->
+        push(socket, "stream_output", %{"event" => %{"type" => "text"}})
+        Process.sleep(50)
+      end)
+
+      assert Process.alive?(socket.channel_pid)
+    end
+  end
+
+  describe "stream_complete" do
+    test "broadcasts completion signal to the run's PubSub topic", %{socket: socket} do
+      run_id = Ash.UUID.generate()
+      topic = "agent_run_output:#{run_id}"
+      CitadelWeb.Endpoint.subscribe(topic)
+
+      push(socket, "stream_complete", %{"run_id" => run_id})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: ^topic,
+        event: "stream_complete",
+        payload: %{}
+      }
+    end
+
+    test "handles missing run_id gracefully", %{socket: socket} do
+      import ExUnit.CaptureLog
+
+      capture_log(fn ->
+        push(socket, "stream_complete", %{})
+        Process.sleep(50)
+      end)
+
+      assert Process.alive?(socket.channel_pid)
+    end
+  end
+
+  describe "unrecognized events" do
+    test "logs a warning and does not crash", %{socket: socket} do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          push(socket, "unknown_event", %{"foo" => "bar"})
+          Process.sleep(50)
+        end)
+
+      assert log =~ "unrecognized event"
+      assert log =~ "unknown_event"
+      assert Process.alive?(socket.channel_pid)
+    end
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,0 +1,21 @@
+defmodule CitadelWeb.ChannelCase do
+  @moduledoc """
+  This module defines the test case to be used by channel tests.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Phoenix.ChannelTest
+      import Citadel.Generator
+
+      @endpoint CitadelWeb.Endpoint
+    end
+  end
+
+  setup tags do
+    Citadel.DataCase.setup_sandbox(tags)
+    :ok
+  end
+end


### PR DESCRIPTION
Add handle_in/3 clauses for stream_output and stream_complete events so the runner can push Claude Code stream-json events through the channel and have them broadcast to "agent_run_output:{run_id}" PubSub topics without any database persistence.

Malformed or unrecognized events are logged with Logger.warning and dropped so the channel never crashes.