### PR TITLE
feat(tasks): add claim_next action to AgentRun for atomic task claiming

### DIFF
--- a/citadel_agent/lib/citadel_agent/client.ex
+++ b/citadel_agent/lib/citadel_agent/client.ex
@@ -5,28 +5,13 @@ defmodule CitadelAgent.Client do
 
   require Logger
 
-  def fetch_next_task do
-    case req_get("/api/agent/tasks/next") do
-      {:ok, %Req.Response{status: 200, body: %{"data" => task}}} ->
-        {:ok, task}
+  def claim_task do
+    case req_post("/api/agent/tasks/claim", %{}) do
+      {:ok, %Req.Response{status: 200, body: %{"data" => data}}} ->
+        {:ok, data}
 
       {:ok, %Req.Response{status: 204}} ->
         {:ok, nil}
-
-      {:ok, %Req.Response{status: status, body: body}} ->
-        {:error, {status, body}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  def create_run(task_id, attrs \\ %{}) do
-    body = Map.put(attrs, "task_id", task_id)
-
-    case req_post("/api/agent/tasks/#{task_id}/runs", body) do
-      {:ok, %Req.Response{status: 201, body: %{"data" => run}}} ->
-        {:ok, run}
 
       {:ok, %Req.Response{status: status, body: body}} ->
         {:error, {status, body}}

--- a/citadel_agent/lib/citadel_agent/preflight.ex
+++ b/citadel_agent/lib/citadel_agent/preflight.ex
@@ -111,7 +111,7 @@ defmodule CitadelAgent.Preflight do
   end
 
   defp check_api do
-    case CitadelAgent.Client.fetch_next_task() do
+    case CitadelAgent.Client.claim_task() do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, "Citadel API unreachable: #{inspect(reason)}"}
     end

--- a/citadel_agent/lib/citadel_agent/worker.ex
+++ b/citadel_agent/lib/citadel_agent/worker.ex
@@ -49,65 +49,34 @@ defmodule CitadelAgent.Worker do
   end
 
   defp process_next_task(state) do
-    case CitadelAgent.Client.fetch_next_task() do
+    case CitadelAgent.Client.claim_task() do
       {:ok, nil} ->
         Logger.debug("No agent-eligible tasks available")
         CitadelAgent.Socket.update_status("idle")
         state
 
-      {:ok, task} ->
-        Logger.info("Picked up task #{task["human_id"]}: #{task["title"]}")
-        execute_task(task, state)
+      {:ok, %{"task" => task, "agent_run" => run}} ->
+        Logger.info("Claimed task #{task["human_id"]}: #{task["title"]}")
+        execute_task(task, run, state)
 
       {:error, reason} ->
-        Logger.error("Failed to fetch next task: #{inspect(reason)}")
+        Logger.error("Failed to claim task: #{inspect(reason)}")
         state
     end
   end
 
-  defp execute_task(task, state) do
+  defp execute_task(task, run, state) do
     case CitadelAgent.config(:project_path) do
       nil ->
         Logger.error("No project_path configured, skipping task #{task["human_id"]}")
         state
 
       project_path ->
-        with {:ok, run} <- create_run(task),
-             {:ok, run} <- mark_running(run) do
-          state = %{state | active_run: run}
-          CitadelAgent.Socket.update_status("working", task["id"])
-          run_task(task, run, project_path)
-          CitadelAgent.Socket.update_status("idle")
-          %{state | active_run: nil}
-        else
-          _ -> state
-        end
-    end
-  end
-
-  defp create_run(task) do
-    case CitadelAgent.Client.create_run(task["id"]) do
-      {:ok, run} ->
-        Logger.info("Created AgentRun #{run["id"]} for task #{task["human_id"]}")
-        {:ok, run}
-
-      {:error, reason} ->
-        Logger.error("Failed to create AgentRun: #{inspect(reason)}")
-        {:error, reason}
-    end
-  end
-
-  defp mark_running(run) do
-    case CitadelAgent.Client.update_run(run["id"], %{
-           "status" => "running",
-           "started_at" => DateTime.utc_now() |> DateTime.to_iso8601()
-         }) do
-      {:ok, run} ->
-        {:ok, run}
-
-      {:error, reason} ->
-        Logger.error("Failed to mark run as running: #{inspect(reason)}")
-        {:error, reason}
+        state = %{state | active_run: run}
+        CitadelAgent.Socket.update_status("working", task["id"])
+        run_task(task, run, project_path)
+        CitadelAgent.Socket.update_status("idle")
+        %{state | active_run: nil}
     end
   end
 

--- a/lib/citadel/tasks.ex
+++ b/lib/citadel/tasks.ex
@@ -83,6 +83,7 @@ defmodule Citadel.Tasks do
     end
 
     resource Citadel.Tasks.AgentRun do
+      define :claim_next_task, action: :claim_next
       define :create_agent_run, action: :create
       define :update_agent_run, action: :update
       define :cancel_agent_run, action: :cancel

--- a/lib/citadel/tasks/agent_run.ex
+++ b/lib/citadel/tasks/agent_run.ex
@@ -40,6 +40,13 @@ defmodule Citadel.Tasks.AgentRun do
       change set_attribute(:completed_at, &DateTime.utc_now/0)
     end
 
+    create :claim_next do
+      accept []
+
+      change relate_actor(:user)
+      change Citadel.Tasks.Changes.ClaimNextTask
+    end
+
     read :list_by_task do
       argument :task_id, :uuid, allow_nil?: false
 
@@ -73,6 +80,7 @@ defmodule Citadel.Tasks.AgentRun do
     prefix "tasks"
 
     publish :create, ["agent_runs", :task_id]
+    publish :claim_next, ["agent_runs", :task_id]
     publish :update, ["agent_runs", :task_id]
     publish :cancel, ["agent_runs", :task_id]
   end

--- a/lib/citadel/tasks/changes/claim_next_task.ex
+++ b/lib/citadel/tasks/changes/claim_next_task.ex
@@ -1,0 +1,71 @@
+defmodule Citadel.Tasks.Changes.ClaimNextTask do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  import Ecto.Query
+
+  @impl true
+  def change(changeset, _opts, context) do
+    Ash.Changeset.before_action(changeset, fn changeset ->
+      workspace_id = context.tenant
+
+      case find_eligible_task(workspace_id) do
+        nil ->
+          Ash.Changeset.add_error(changeset,
+            field: :task_id,
+            message: "no tasks available"
+          )
+
+        task_id ->
+          changeset
+          |> Ash.Changeset.force_change_attribute(:task_id, task_id)
+          |> Ash.Changeset.force_change_attribute(:workspace_id, workspace_id)
+          |> Ash.Changeset.force_change_attribute(:status, :running)
+          |> Ash.Changeset.force_change_attribute(:started_at, DateTime.utc_now())
+      end
+    end)
+  end
+
+  defp find_eligible_task(workspace_id) do
+    active_runs_subquery =
+      from ar in "agent_runs",
+        where: ar.task_id == parent_as(:task).id,
+        where: ar.status in ["pending", "running"],
+        select: 1
+
+    incomplete_deps_subquery =
+      from td in "task_dependencies",
+        join: dep in "tasks", on: dep.id == td.depends_on_task_id,
+        join: dep_ts in "task_states", on: dep_ts.id == dep.task_state_id,
+        where: td.task_id == parent_as(:task).id,
+        where: dep_ts.is_complete != true,
+        select: 1
+
+    priority_order =
+      dynamic(
+        [task: t],
+        fragment(
+          "CASE ? WHEN 'urgent' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END",
+          t.priority
+        )
+      )
+
+    query =
+      from t in Citadel.Tasks.Task,
+        as: :task,
+        join: ts in Citadel.Tasks.TaskState,
+        on: ts.id == t.task_state_id,
+        where: t.workspace_id == ^workspace_id,
+        where: t.agent_eligible == true,
+        where: ts.is_complete != true,
+        where: ts.name != "In Review",
+        where: not exists(active_runs_subquery),
+        where: not exists(incomplete_deps_subquery),
+        order_by: ^[desc: priority_order, asc: dynamic([task: t], t.inserted_at)],
+        limit: 1,
+        lock: "FOR UPDATE OF t0 SKIP LOCKED",
+        select: t.id
+
+    Citadel.Repo.one(query)
+  end
+end

--- a/lib/citadel/tasks/changes/claim_next_task.ex
+++ b/lib/citadel/tasks/changes/claim_next_task.ex
@@ -35,8 +35,10 @@ defmodule Citadel.Tasks.Changes.ClaimNextTask do
 
     incomplete_deps_subquery =
       from td in "task_dependencies",
-        join: dep in "tasks", on: dep.id == td.depends_on_task_id,
-        join: dep_ts in "task_states", on: dep_ts.id == dep.task_state_id,
+        join: dep in "tasks",
+        on: dep.id == td.depends_on_task_id,
+        join: dep_ts in "task_states",
+        on: dep_ts.id == dep.task_state_id,
         where: td.task_id == parent_as(:task).id,
         where: dep_ts.is_complete != true,
         select: 1

--- a/lib/citadel_web/controllers/api/agent_controller.ex
+++ b/lib/citadel_web/controllers/api/agent_controller.ex
@@ -3,51 +3,22 @@ defmodule CitadelWeb.Api.AgentController do
 
   alias Citadel.Tasks
 
-  def next_task(conn, _params) do
-    require Ash.Query
-
+  def claim_task(conn, _params) do
     tenant = Ash.PlugHelpers.get_tenant(conn)
     actor = conn.assigns.current_user
 
-    case Citadel.Tasks.Task
-         |> Ash.Query.filter(agent_eligible == true)
-         |> Ash.Query.filter(not exists(agent_runs, status in [:pending, :running]))
-         |> Ash.Query.filter(task_state.is_complete != true and task_state.name != "In Review")
-         |> Ash.Query.filter(not exists(dependencies, task_state.is_complete != true))
-         |> Ash.Query.sort(priority: :desc, inserted_at: :asc)
-         |> Ash.Query.limit(1)
-         |> Ash.Query.load([:task_state, :parent_task])
-         |> Ash.read(actor: actor, tenant: tenant) do
-      {:ok, [task]} ->
-        conn
-        |> put_status(:ok)
-        |> render(:task, task: task)
-
-      {:ok, []} ->
-        send_resp(conn, :no_content, "")
-    end
-  end
-
-  def create_run(conn, %{"task_id" => task_id} = params) do
-    tenant = Ash.PlugHelpers.get_tenant(conn)
-    actor = conn.assigns.current_user
-
-    input =
-      params
-      |> Map.take(["status"])
-      |> Map.put("task_id", task_id)
-      |> atomize_keys()
-
-    case Tasks.create_agent_run(input, actor: actor, tenant: tenant) do
+    case Tasks.claim_next_task(
+           actor: actor,
+           tenant: tenant,
+           load: [task: [:task_state, :parent_task]]
+         ) do
       {:ok, agent_run} ->
         conn
-        |> put_status(:created)
-        |> render(:agent_run, agent_run: agent_run)
+        |> put_status(:ok)
+        |> render(:claim, agent_run: agent_run)
 
-      {:error, %Ash.Error.Invalid{} = error} ->
-        conn
-        |> put_status(:unprocessable_entity)
-        |> render(:error, error: error)
+      {:error, %Ash.Error.Invalid{}} ->
+        send_resp(conn, :no_content, "")
     end
   end
 

--- a/lib/citadel_web/controllers/api/agent_json.ex
+++ b/lib/citadel_web/controllers/api/agent_json.ex
@@ -1,4 +1,39 @@
 defmodule CitadelWeb.Api.AgentJSON do
+  def claim(%{agent_run: agent_run}) do
+    task = agent_run.task
+
+    %{
+      data: %{
+        task: %{
+          id: task.id,
+          human_id: task.human_id,
+          title: task.title,
+          description: task.description,
+          priority: task.priority,
+          due_date: task.due_date,
+          agent_eligible: task.agent_eligible,
+          parent_task_id: task.parent_task_id,
+          parent_human_id: if(task.parent_task, do: task.parent_task.human_id),
+          task_state: %{
+            id: task.task_state.id,
+            name: task.task_state.name
+          },
+          inserted_at: task.inserted_at,
+          updated_at: task.updated_at
+        },
+        agent_run: %{
+          id: agent_run.id,
+          task_id: agent_run.task_id,
+          status: agent_run.status,
+          started_at: agent_run.started_at,
+          completed_at: agent_run.completed_at,
+          inserted_at: agent_run.inserted_at,
+          updated_at: agent_run.updated_at
+        }
+      }
+    }
+  end
+
   def task(%{task: task}) do
     %{
       data: %{

--- a/lib/citadel_web/router.ex
+++ b/lib/citadel_web/router.ex
@@ -159,9 +159,8 @@ defmodule CitadelWeb.Router do
     pipe_through :api
 
     get "/agent/task-states", AgentController, :list_task_states
-    get "/agent/tasks/next", AgentController, :next_task
+    post "/agent/tasks/claim", AgentController, :claim_task
     patch "/agent/tasks/:id", AgentController, :update_task
-    post "/agent/tasks/:task_id/runs", AgentController, :create_run
     patch "/agent/runs/:id", AgentController, :update_run
     post "/agent/runs/:id/cancel", AgentController, :cancel_run
     post "/agent/runs/:id/events", AgentController, :create_run_event

--- a/test/citadel/tasks/claim_next_task_test.exs
+++ b/test/citadel/tasks/claim_next_task_test.exs
@@ -1,0 +1,313 @@
+defmodule Citadel.Tasks.ClaimNextTaskTest do
+  use Citadel.DataCase, async: false
+
+  alias Citadel.Tasks
+
+  setup do
+    user = generate(user())
+    workspace = generate(workspace([], actor: user))
+
+    todo_state =
+      Tasks.create_task_state!(%{
+        name: "To Do #{System.unique_integer([:positive])}",
+        order: 1,
+        is_complete: false
+      })
+
+    done_state =
+      Tasks.create_task_state!(%{
+        name: "Done #{System.unique_integer([:positive])}",
+        order: 3,
+        is_complete: true
+      })
+
+    require Ash.Query
+
+    in_review_state =
+      case Citadel.Tasks.TaskState
+           |> Ash.Query.filter(name == "In Review")
+           |> Ash.read_one(authorize?: false) do
+        {:ok, nil} ->
+          Tasks.create_task_state!(%{name: "In Review", order: 2, is_complete: false})
+
+        {:ok, existing} ->
+          existing
+      end
+
+    {:ok,
+     user: user,
+     workspace: workspace,
+     todo_state: todo_state,
+     done_state: done_state,
+     in_review_state: in_review_state}
+  end
+
+  defp create_eligible_task(ctx, opts \\ []) do
+    Tasks.create_task!(
+      %{
+        title: "Eligible Task #{System.unique_integer([:positive])}",
+        task_state_id: ctx.todo_state.id,
+        workspace_id: ctx.workspace.id,
+        agent_eligible: true,
+        priority: Keyword.get(opts, :priority, :medium)
+      },
+      actor: ctx.user,
+      tenant: ctx.workspace.id
+    )
+  end
+
+  describe "claim_next_task/1" do
+    test "claims the next eligible task and returns a running agent run", ctx do
+      task = create_eligible_task(ctx)
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id,
+          load: [task: [:task_state, :parent_task]]
+        )
+
+      assert agent_run.status == :running
+      assert agent_run.started_at != nil
+      assert agent_run.task_id == task.id
+      assert agent_run.workspace_id == ctx.workspace.id
+      assert agent_run.user_id == ctx.user.id
+      assert agent_run.task.id == task.id
+      assert agent_run.task.task_state.id == ctx.todo_state.id
+    end
+
+    test "returns error when no eligible tasks exist", ctx do
+      assert {:error, _} =
+               Tasks.claim_next_task(
+                 actor: ctx.user,
+                 tenant: ctx.workspace.id
+               )
+    end
+
+    test "skips tasks with active (pending) agent runs", ctx do
+      task_with_run = create_eligible_task(ctx)
+      eligible_task = create_eligible_task(ctx)
+
+      Tasks.create_agent_run!(
+        %{task_id: task_with_run.id, status: :pending},
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == eligible_task.id
+    end
+
+    test "skips tasks with running agent runs", ctx do
+      task_with_run = create_eligible_task(ctx)
+      eligible_task = create_eligible_task(ctx)
+
+      run =
+        Tasks.create_agent_run!(
+          %{task_id: task_with_run.id},
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      Tasks.update_agent_run!(
+        run,
+        %{status: :running, started_at: DateTime.utc_now()},
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == eligible_task.id
+    end
+
+    test "allows tasks with completed/failed/cancelled agent runs", ctx do
+      task = create_eligible_task(ctx)
+
+      run =
+        Tasks.create_agent_run!(
+          %{task_id: task.id},
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      Tasks.update_agent_run!(
+        run,
+        %{status: :completed, completed_at: DateTime.utc_now()},
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == task.id
+    end
+
+    test "skips completed tasks", ctx do
+      Tasks.create_task!(
+        %{
+          title: "Completed Task #{System.unique_integer([:positive])}",
+          task_state_id: ctx.done_state.id,
+          workspace_id: ctx.workspace.id,
+          agent_eligible: true
+        },
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      eligible_task = create_eligible_task(ctx)
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == eligible_task.id
+    end
+
+    test "skips tasks in 'In Review' state", ctx do
+      Tasks.create_task!(
+        %{
+          title: "In Review Task #{System.unique_integer([:positive])}",
+          task_state_id: ctx.in_review_state.id,
+          workspace_id: ctx.workspace.id,
+          agent_eligible: true
+        },
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      eligible_task = create_eligible_task(ctx)
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == eligible_task.id
+    end
+
+    test "skips tasks with incomplete dependencies", ctx do
+      dependency_task =
+        Tasks.create_task!(
+          %{
+            title: "Dependency #{System.unique_integer([:positive])}",
+            task_state_id: ctx.todo_state.id,
+            workspace_id: ctx.workspace.id
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      blocked_task = create_eligible_task(ctx)
+
+      Tasks.create_task_dependency!(
+        %{task_id: blocked_task.id, depends_on_task_id: dependency_task.id},
+        authorize?: false
+      )
+
+      unblocked_task = create_eligible_task(ctx)
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == unblocked_task.id
+    end
+
+    test "allows tasks with completed dependencies", ctx do
+      dependency_task =
+        Tasks.create_task!(
+          %{
+            title: "Completed Dep #{System.unique_integer([:positive])}",
+            task_state_id: ctx.done_state.id,
+            workspace_id: ctx.workspace.id
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      task = create_eligible_task(ctx)
+
+      Tasks.create_task_dependency!(
+        %{task_id: task.id, depends_on_task_id: dependency_task.id},
+        authorize?: false
+      )
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == task.id
+    end
+
+    test "skips tasks where agent_eligible is false", ctx do
+      Tasks.create_task!(
+        %{
+          title: "Not Eligible #{System.unique_integer([:positive])}",
+          task_state_id: ctx.todo_state.id,
+          workspace_id: ctx.workspace.id,
+          agent_eligible: false
+        },
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      eligible_task = create_eligible_task(ctx)
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == eligible_task.id
+    end
+
+    test "prioritizes higher priority tasks", ctx do
+      _low = create_eligible_task(ctx, priority: :low)
+      urgent = create_eligible_task(ctx, priority: :urgent)
+      _medium = create_eligible_task(ctx, priority: :medium)
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == urgent.id
+    end
+
+    test "uses inserted_at as tiebreaker for same priority", ctx do
+      first = create_eligible_task(ctx, priority: :high)
+      _second = create_eligible_task(ctx, priority: :high)
+
+      agent_run =
+        Tasks.claim_next_task!(
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert agent_run.task_id == first.id
+    end
+  end
+end

--- a/test/citadel_web/controllers/api/agent_claim_concurrency_test.exs
+++ b/test/citadel_web/controllers/api/agent_claim_concurrency_test.exs
@@ -1,0 +1,120 @@
+defmodule CitadelWeb.Api.AgentClaimConcurrencyTest do
+  use CitadelWeb.ConnCase, async: false
+
+  alias Citadel.Accounts.ApiKey
+  alias Citadel.Tasks
+
+  setup do
+    user = generate(user())
+    organization = generate(organization([], actor: user))
+    workspace = generate(workspace([organization_id: organization.id], actor: user))
+
+    task_state =
+      Tasks.create_task_state!(%{
+        name: "Todo #{System.unique_integer([:positive])}",
+        order: 1
+      })
+
+    expires_at = DateTime.add(DateTime.utc_now(), 30, :day)
+
+    {:ok, api_key} =
+      ApiKey
+      |> Ash.Changeset.for_create(:create, %{
+        name: "Test Agent Key",
+        user_id: user.id,
+        workspace_id: workspace.id,
+        expires_at: expires_at
+      })
+      |> Ash.create(authorize?: false)
+
+    raw_key = api_key.__metadata__[:plaintext_api_key]
+
+    %{raw_key: raw_key, user: user, workspace: workspace, task_state: task_state}
+  end
+
+  defp create_task(workspace, user, task_state, attrs \\ []) do
+    defaults = [workspace_id: workspace.id, task_state_id: task_state.id, agent_eligible: true]
+    generate(task(Keyword.merge(defaults, attrs), actor: user, tenant: workspace.id))
+  end
+
+  defp claim_request(raw_key) do
+    build_conn()
+    |> put_req_header("authorization", "Bearer #{raw_key}")
+    |> put_req_header("accept", "application/json")
+    |> post(~p"/api/agent/tasks/claim")
+  end
+
+  describe "concurrent POST /api/agent/tasks/claim" do
+    test "5 concurrent claims for 1 task yield exactly 1 winner", ctx do
+      _task = create_task(ctx.workspace, ctx.user, ctx.task_state)
+
+      results =
+        1..5
+        |> Enum.map(fn _ ->
+          Task.async(fn -> claim_request(ctx.raw_key) end)
+        end)
+        |> Enum.map(&Task.await/1)
+
+      statuses = Enum.map(results, & &1.status)
+      assert Enum.count(statuses, &(&1 == 200)) == 1
+      assert Enum.count(statuses, &(&1 == 204)) == 4
+    end
+
+    test "N concurrent claims for M tasks yield exactly M winners", ctx do
+      num_tasks = 3
+      num_claimers = 8
+
+      tasks =
+        for _ <- 1..num_tasks do
+          create_task(ctx.workspace, ctx.user, ctx.task_state)
+        end
+
+      results =
+        1..num_claimers
+        |> Enum.map(fn _ ->
+          Task.async(fn -> claim_request(ctx.raw_key) end)
+        end)
+        |> Enum.map(&Task.await/1)
+
+      statuses = Enum.map(results, & &1.status)
+      winners = Enum.count(statuses, &(&1 == 200))
+      losers = Enum.count(statuses, &(&1 == 204))
+
+      assert winners == num_tasks
+      assert losers == num_claimers - num_tasks
+
+      won_task_ids =
+        results
+        |> Enum.filter(&(&1.status == 200))
+        |> Enum.map(fn conn ->
+          body = Jason.decode!(conn.resp_body)
+          body["data"]["task"]["id"]
+        end)
+
+      assert length(Enum.uniq(won_task_ids)) == num_tasks
+      assert MapSet.subset?(MapSet.new(won_task_ids), MapSet.new(Enum.map(tasks, & &1.id)))
+    end
+
+    test "tasks with existing running runs are never claimed", ctx do
+      task = create_task(ctx.workspace, ctx.user, ctx.task_state)
+
+      generate(
+        agent_run(
+          [task_id: task.id, status: :running],
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+      )
+
+      results =
+        1..5
+        |> Enum.map(fn _ ->
+          Task.async(fn -> claim_request(ctx.raw_key) end)
+        end)
+        |> Enum.map(&Task.await/1)
+
+      statuses = Enum.map(results, & &1.status)
+      assert Enum.all?(statuses, &(&1 == 204))
+    end
+  end
+end

--- a/test/citadel_web/controllers/api/agent_controller_test.exs
+++ b/test/citadel_web/controllers/api/agent_controller_test.exs
@@ -42,21 +42,23 @@ defmodule CitadelWeb.Api.AgentControllerTest do
     generate(task(Keyword.merge(defaults, attrs), actor: user, tenant: workspace.id))
   end
 
-  describe "GET /api/agent/tasks/next" do
-    test "returns the next eligible task", ctx do
+  describe "POST /api/agent/tasks/claim" do
+    test "returns task and agent run when a task is available", ctx do
       task = create_task(ctx.workspace, ctx.user, ctx.task_state)
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert %{"data" => data} = json_response(conn, 200)
-      assert data["id"] == task.id
-      assert data["title"] == task.title
-      assert data["agent_eligible"] == true
-      assert data["task_state"]["name"] != nil
+      assert data["task"]["id"] == task.id
+      assert data["task"]["title"] == task.title
+      assert data["task"]["agent_eligible"] == true
+      assert data["task"]["task_state"]["name"] != nil
+      assert data["agent_run"]["task_id"] == task.id
+      assert data["agent_run"]["status"] == "running"
     end
 
     test "returns 204 when no tasks available", ctx do
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert response(conn, 204)
     end
@@ -64,7 +66,7 @@ defmodule CitadelWeb.Api.AgentControllerTest do
     test "skips tasks that are not agent_eligible", ctx do
       _non_eligible = create_task(ctx.workspace, ctx.user, ctx.task_state, agent_eligible: false)
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert response(conn, 204)
     end
@@ -80,7 +82,7 @@ defmodule CitadelWeb.Api.AgentControllerTest do
         )
       )
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert response(conn, 204)
     end
@@ -96,7 +98,7 @@ defmodule CitadelWeb.Api.AgentControllerTest do
         )
       )
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert response(conn, 204)
     end
@@ -118,10 +120,10 @@ defmodule CitadelWeb.Api.AgentControllerTest do
         tenant: ctx.workspace.id
       )
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert %{"data" => data} = json_response(conn, 200)
-      assert data["id"] == task.id
+      assert data["task"]["id"] == task.id
     end
 
     test "returns tasks with failed agent runs", ctx do
@@ -138,10 +140,10 @@ defmodule CitadelWeb.Api.AgentControllerTest do
 
       Tasks.update_agent_run!(run, %{status: :failed}, actor: ctx.user, tenant: ctx.workspace.id)
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert %{"data" => data} = json_response(conn, 200)
-      assert data["id"] == task.id
+      assert data["task"]["id"] == task.id
     end
 
     test "skips tasks with incomplete dependencies", ctx do
@@ -154,11 +156,10 @@ defmodule CitadelWeb.Api.AgentControllerTest do
         tenant: ctx.workspace.id
       )
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
-      # The blocked task should be skipped, but the dependency itself is eligible
       assert %{"data" => data} = json_response(conn, 200)
-      assert data["id"] == dependency.id
+      assert data["task"]["id"] == dependency.id
     end
 
     test "returns tasks whose dependencies are all complete", ctx do
@@ -178,10 +179,10 @@ defmodule CitadelWeb.Api.AgentControllerTest do
         tenant: ctx.workspace.id
       )
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert %{"data" => data} = json_response(conn, 200)
-      assert data["id"] == task.id
+      assert data["task"]["id"] == task.id
     end
 
     test "skips task when any dependency is incomplete", ctx do
@@ -208,69 +209,48 @@ defmodule CitadelWeb.Api.AgentControllerTest do
         tenant: ctx.workspace.id
       )
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
-      # Task is blocked, but its two dependencies are eligible
       assert %{"data" => data} = json_response(conn, 200)
-      assert data["id"] in [complete_dep.id, incomplete_dep.id]
-      assert data["id"] != task.id
+      assert data["task"]["id"] in [complete_dep.id, incomplete_dep.id]
+      assert data["task"]["id"] != task.id
     end
 
     test "includes parent task info for subtasks", ctx do
       parent = create_task(ctx.workspace, ctx.user, ctx.task_state)
       _child = create_task(ctx.workspace, ctx.user, ctx.task_state, parent_task_id: parent.id)
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert %{"data" => data} = json_response(conn, 200)
+      task_data = data["task"]
 
-      if data["parent_task_id"] != nil do
-        assert data["parent_task_id"] == parent.id
-        assert data["parent_human_id"] == parent.human_id
+      if task_data["parent_task_id"] != nil do
+        assert task_data["parent_task_id"] == parent.id
+        assert task_data["parent_human_id"] == parent.human_id
       else
-        assert data["parent_task_id"] == nil
-        assert data["parent_human_id"] == nil
+        assert task_data["parent_task_id"] == nil
+        assert task_data["parent_human_id"] == nil
       end
     end
 
     test "returns null parent info for standalone tasks", ctx do
       _task = create_task(ctx.workspace, ctx.user, ctx.task_state)
 
-      conn = get(ctx.conn, ~p"/api/agent/tasks/next")
+      conn = post(ctx.conn, ~p"/api/agent/tasks/claim")
 
       assert %{"data" => data} = json_response(conn, 200)
-      assert data["parent_task_id"] == nil
-      assert data["parent_human_id"] == nil
+      assert data["task"]["parent_task_id"] == nil
+      assert data["task"]["parent_human_id"] == nil
     end
 
     test "returns 401 without authentication" do
       conn =
         build_conn()
         |> put_req_header("accept", "application/json")
-        |> get(~p"/api/agent/tasks/next")
+        |> post(~p"/api/agent/tasks/claim")
 
       assert json_response(conn, 401)
-    end
-  end
-
-  describe "POST /api/agent/tasks/:task_id/runs" do
-    test "creates an agent run", ctx do
-      task = create_task(ctx.workspace, ctx.user, ctx.task_state)
-
-      conn = post(ctx.conn, ~p"/api/agent/tasks/#{task.id}/runs", %{})
-
-      assert %{"data" => data} = json_response(conn, 201)
-      assert data["task_id"] == task.id
-      assert data["status"] == "pending"
-    end
-
-    test "creates an agent run with custom status", ctx do
-      task = create_task(ctx.workspace, ctx.user, ctx.task_state)
-
-      conn = post(ctx.conn, ~p"/api/agent/tasks/#{task.id}/runs", %{"status" => "running"})
-
-      assert %{"data" => data} = json_response(conn, 201)
-      assert data["status"] == "running"
     end
   end
 


### PR DESCRIPTION
Adds a `claim_next` create action on AgentRun that atomically selects and locks the next eligible task using FOR UPDATE SKIP LOCKED, preventing race conditions when multiple agents run concurrently.

- New `ClaimNextTask` change module builds an Ecto query with all eligibility filters (agent_eligible, no active runs, non-complete state, all deps done) and executes it inside a before_action hook with row-level locking
- `claim_next` action on AgentRun sets status :running and started_at on the locked task's run
- `claim_next_task` code interface added to the Citadel.Tasks domain
- Unit tests cover successful claim, no tasks available, tasks with active runs, completed tasks, and tasks with incomplete dependencies