### PR TITLE
feat: make PR creation idempotent with find-before-create logic

### DIFF
--- a/citadel_agent/config/config.exs
+++ b/citadel_agent/config/config.exs
@@ -2,8 +2,8 @@ import Config
 
 config :citadel_agent,
   citadel_url: "http://localhost:4100",
-  api_key: nil,
-  project_path: nil,
+  api_key: System.get_env("CITADEL_DEV_API_KEY"),
+  project_path: File.cwd!(),
   poll_interval: 10_000
 
 import_config "#{config_env()}.exs"

--- a/citadel_agent/lib/citadel_agent/github.ex
+++ b/citadel_agent/lib/citadel_agent/github.ex
@@ -3,6 +3,49 @@ defmodule CitadelAgent.GitHub do
 
   @github_api "https://api.github.com"
 
+  def find_pull_request(owner, repo, head, base) do
+    token = CitadelAgent.config(:github_token)
+
+    unless token do
+      {:error, "GITHUB_TOKEN not configured"}
+    else
+      url = "#{@github_api}/repos/#{owner}/#{repo}/pulls"
+
+      opts =
+        Keyword.merge(
+          [
+            params: [head: "#{owner}:#{head}", base: base, state: "open"],
+            headers: [
+              {"authorization", "Bearer #{token}"},
+              {"accept", "application/vnd.github+v3+json"}
+            ]
+          ],
+          req_options()
+        )
+
+      case Req.get(url, opts) do
+        {:ok, %Req.Response{status: 200, body: [pr | _]}} when is_map(pr) ->
+          {:ok, pr["html_url"]}
+
+        {:ok, %Req.Response{status: 200, body: []}} ->
+          {:ok, nil}
+
+        {:ok, %Req.Response{status: status, body: body}} when is_map(body) ->
+          message = body["message"] || "HTTP #{status}"
+          Logger.warning("GitHub API error checking for existing PR: #{status} - #{message}")
+          {:ok, nil}
+
+        {:ok, %Req.Response{status: status}} ->
+          Logger.warning("GitHub API error checking for existing PR: HTTP #{status}")
+          {:ok, nil}
+
+        {:error, exception} ->
+          Logger.warning("GitHub API request failed checking for PR: #{Exception.message(exception)}")
+          {:ok, nil}
+      end
+    end
+  end
+
   def create_pull_request(owner, repo, head, base, title, body) do
     token = CitadelAgent.config(:github_token)
 
@@ -27,10 +70,26 @@ defmodule CitadelAgent.GitHub do
         {:ok, %Req.Response{status: status, body: body}} when status in [201] ->
           {:ok, body["html_url"]}
 
-        {:ok, %Req.Response{status: status, body: body}} ->
+        {:ok, %Req.Response{status: 422, body: body}} when is_map(body) ->
+          errors = body["errors"] || []
+          error_messages = Enum.map_join(errors, "; ", &(&1["message"] || inspect(&1)))
+          message = body["message"] || "Validation Failed"
+          Logger.warning("GitHub API error: 422 - #{message}: #{error_messages}")
+
+          if pr_already_exists?(errors) do
+            {:ok, :already_exists}
+          else
+            {:error, "#{message}: #{error_messages}"}
+          end
+
+        {:ok, %Req.Response{status: status, body: body}} when is_map(body) ->
           message = body["message"] || "HTTP #{status}"
           Logger.warning("GitHub API error: #{status} - #{message}")
           {:error, message}
+
+        {:ok, %Req.Response{status: status}} ->
+          Logger.warning("GitHub API error: #{status}")
+          {:error, "HTTP #{status}"}
 
         {:error, exception} ->
           Logger.warning("GitHub API request failed: #{Exception.message(exception)}")
@@ -52,6 +111,18 @@ defmodule CitadelAgent.GitHub do
         {:error, "Failed to get remote URL: #{String.trim(output)}"}
     end
   end
+
+  defp pr_already_exists?(errors) when is_list(errors) do
+    Enum.any?(errors, fn
+      %{"message" => msg} when is_binary(msg) ->
+        String.contains?(msg, "A pull request already exists")
+
+      _ ->
+        false
+    end)
+  end
+
+  defp pr_already_exists?(_), do: false
 
   defp req_options do
     Application.get_env(:citadel_agent, :github_req_options, [])

--- a/citadel_agent/lib/citadel_agent/runner.ex
+++ b/citadel_agent/lib/citadel_agent/runner.ex
@@ -170,65 +170,83 @@ defmodule CitadelAgent.Runner do
     local_exists? = branch_exists_locally?(feature_branch, project_path)
     remote_exists? = branch_exists_on_remote?(feature_branch, project_path)
 
-    cond do
-      local_exists? and remote_exists? ->
-        fetch_and_update_branch(feature_branch, project_path)
+    result =
+      cond do
+        local_exists? and remote_exists? ->
+          fetch_and_update_branch(feature_branch, project_path)
 
-      local_exists? ->
-        :ok
+        local_exists? ->
+          :ok
 
-      remote_exists? ->
-        System.cmd(
-          "git",
-          ["branch", feature_branch, "origin/#{feature_branch}"],
-          cd: project_path,
-          stderr_to_stdout: true
-        )
+        remote_exists? ->
+          System.cmd(
+            "git",
+            ["branch", feature_branch, "origin/#{feature_branch}"],
+            cd: project_path,
+            stderr_to_stdout: true
+          )
 
-        :ok
+          :ok
 
-      true ->
-        case System.cmd(
-               "git",
-               ["branch", feature_branch, "origin/main"],
-               cd: project_path,
-               stderr_to_stdout: true
-             ) do
-          {_output, 0} ->
-            Logger.info("Created feature branch #{feature_branch} from origin/main")
-            create_draft_pr(feature_branch, task, project_path)
-            :ok
+        true ->
+          case System.cmd(
+                 "git",
+                 ["branch", feature_branch, "origin/main"],
+                 cd: project_path,
+                 stderr_to_stdout: true
+               ) do
+            {_output, 0} ->
+              Logger.info("Created feature branch #{feature_branch} from origin/main")
+              :ok
 
-          {output, _code} ->
-            {:error, "Failed to create feature branch #{feature_branch}: #{output}"}
-        end
+            {output, _code} ->
+              {:error, "Failed to create feature branch #{feature_branch}: #{output}"}
+          end
+      end
+
+    if result == :ok do
+      ensure_draft_pr(feature_branch, task, project_path)
     end
+
+    result
   end
 
-  defp create_draft_pr(feature_branch, task, project_path) do
+  defp ensure_draft_pr(feature_branch, task, project_path) do
     parent_id = task["parent_human_id"]
 
     try do
-      {_, 0} =
-        System.cmd("git", ["push", "-u", "origin", feature_branch],
-          cd: project_path,
-          stderr_to_stdout: true
-        )
-
-      Logger.info("Pushed #{feature_branch} to origin")
-
-      {:ok, pr_body} = generate_pr_description(task, project_path)
       {:ok, {owner, repo}} = CitadelAgent.GitHub.parse_remote_url(project_path)
 
-      case CitadelAgent.GitHub.create_pull_request(owner, repo, feature_branch, "main", parent_id, pr_body) do
-        {:ok, url} ->
-          Logger.info("Created draft PR: #{url}")
+      case CitadelAgent.GitHub.find_pull_request(owner, repo, feature_branch, "main") do
+        {:ok, url} when is_binary(url) ->
+          Logger.info("PR already exists for #{feature_branch}: #{url}")
 
-        {:error, reason} ->
-          Logger.warning("Failed to create PR for #{feature_branch}: #{reason}")
+        _ ->
+          {_, 0} =
+            System.cmd("git", ["push", "-u", "origin", feature_branch],
+              cd: project_path,
+              stderr_to_stdout: true
+            )
+
+          Logger.info("Pushed #{feature_branch} to origin")
+
+          {:ok, pr_body} = generate_pr_description(task, project_path)
+
+          case CitadelAgent.GitHub.create_pull_request(owner, repo, feature_branch, "main", parent_id, pr_body) do
+            {:ok, :already_exists} ->
+              Logger.info("PR already exists for #{feature_branch} (detected during creation)")
+
+            {:ok, url} ->
+              Logger.info("Created draft PR: #{url}")
+
+            {:error, reason} ->
+              Logger.warning("Failed to create PR for #{feature_branch}: #{reason}")
+          end
       end
     rescue
-      e -> Logger.warning("Failed to create PR for #{feature_branch}: #{Exception.message(e)}")
+      e ->
+        Logger.warning("Failed to create PR for #{feature_branch}: #{Exception.message(e)}")
+        Logger.warning("Stacktrace: #{Exception.format(:error, e, __STACKTRACE__)}")
     end
   end
 
@@ -438,10 +456,10 @@ defmodule CitadelAgent.Runner do
     |> String.split("\n", trim: true)
     |> Enum.reduce([], fn line, acc ->
       case Jason.decode(line) do
-        {:ok, %{"type" => "assistant", "message" => %{"content" => content}}} ->
+        {:ok, %{"type" => "assistant", "message" => %{"content" => content}}} when is_list(content) ->
           text =
             content
-            |> Enum.filter(&(&1["type"] == "text"))
+            |> Enum.filter(&(is_map(&1) and &1["type"] == "text"))
             |> Enum.map_join("", & &1["text"])
 
           [text | acc]
@@ -449,10 +467,10 @@ defmodule CitadelAgent.Runner do
         {:ok, %{"type" => "content_block_delta", "delta" => %{"text" => text}}} ->
           [text | acc]
 
-        {:ok, %{"type" => "result", "result" => result}} ->
+        {:ok, %{"type" => "result", "result" => result}} when is_map(result) ->
           text =
             (result["content"] || [])
-            |> Enum.filter(&(&1["type"] == "text"))
+            |> Enum.filter(&(is_map(&1) and &1["type"] == "text"))
             |> Enum.map_join("", & &1["text"])
 
           [text | acc]

--- a/citadel_agent/test/citadel_agent/github_test.exs
+++ b/citadel_agent/test/citadel_agent/github_test.exs
@@ -116,14 +116,37 @@ defmodule CitadelAgent.GitHubTest do
                GitHub.create_pull_request("o", "r", "head", "base", "Title", "Body")
     end
 
-    test "returns error on API failure with message" do
+    test "returns :already_exists when PR already exists" do
       Req.Test.stub(:github_api, fn conn ->
         conn
         |> Plug.Conn.put_resp_content_type("application/json")
-        |> Plug.Conn.send_resp(422, Jason.encode!(%{"message" => "Validation Failed"}))
+        |> Plug.Conn.send_resp(
+          422,
+          Jason.encode!(%{
+            "message" => "Validation Failed",
+            "errors" => [%{"message" => "A pull request already exists for owner:head."}]
+          })
+        )
       end)
 
-      assert {:error, "Validation Failed"} =
+      assert {:ok, :already_exists} =
+               GitHub.create_pull_request("o", "r", "head", "base", "Title", "Body")
+    end
+
+    test "returns error on 422 with non-duplicate error" do
+      Req.Test.stub(:github_api, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          422,
+          Jason.encode!(%{
+            "message" => "Validation Failed",
+            "errors" => [%{"message" => "No commits between main and head"}]
+          })
+        )
+      end)
+
+      assert {:error, "Validation Failed: No commits between main and head"} =
                GitHub.create_pull_request("o", "r", "head", "base", "Title", "Body")
     end
 
@@ -143,6 +166,88 @@ defmodule CitadelAgent.GitHubTest do
 
       assert {:error, "GITHUB_TOKEN not configured"} =
                GitHub.create_pull_request("owner", "repo", "feature", "main", "Title", "Body")
+    end
+  end
+
+  describe "find_pull_request/4" do
+    setup do
+      original_token = Application.get_env(:citadel_agent, :github_token)
+      original_req_opts = Application.get_env(:citadel_agent, :github_req_options)
+
+      Application.put_env(:citadel_agent, :github_token, "test-token-123")
+      Application.put_env(:citadel_agent, :github_req_options, plug: {Req.Test, :github_api})
+
+      on_exit(fn ->
+        if original_token,
+          do: Application.put_env(:citadel_agent, :github_token, original_token),
+          else: Application.delete_env(:citadel_agent, :github_token)
+
+        if original_req_opts,
+          do: Application.put_env(:citadel_agent, :github_req_options, original_req_opts),
+          else: Application.delete_env(:citadel_agent, :github_req_options)
+      end)
+
+      :ok
+    end
+
+    test "returns PR URL when PR exists" do
+      Req.Test.stub(:github_api, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([%{"html_url" => "https://github.com/o/r/pull/5"}]))
+      end)
+
+      assert {:ok, "https://github.com/o/r/pull/5"} =
+               GitHub.find_pull_request("o", "r", "feature-branch", "main")
+    end
+
+    test "returns nil when no PR exists" do
+      Req.Test.stub(:github_api, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([]))
+      end)
+
+      assert {:ok, nil} = GitHub.find_pull_request("o", "r", "feature-branch", "main")
+    end
+
+    test "sends correct query parameters" do
+      test_pid = self()
+
+      Req.Test.stub(:github_api, fn conn ->
+        send(test_pid, {:find_pr_request, conn})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!([]))
+      end)
+
+      GitHub.find_pull_request("owner", "repo", "my-branch", "main")
+
+      assert_received {:find_pr_request, conn}
+      assert conn.method == "GET"
+      assert conn.request_path == "/repos/owner/repo/pulls"
+      params = URI.decode_query(conn.query_string)
+      assert params["head"] == "owner:my-branch"
+      assert params["base"] == "main"
+      assert params["state"] == "open"
+    end
+
+    test "returns nil on API error" do
+      Req.Test.stub(:github_api, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(500, Jason.encode!(%{"message" => "Internal Server Error"}))
+      end)
+
+      assert {:ok, nil} = GitHub.find_pull_request("o", "r", "feature-branch", "main")
+    end
+
+    test "returns error when token is not configured" do
+      Application.delete_env(:citadel_agent, :github_token)
+
+      assert {:error, "GITHUB_TOKEN not configured"} =
+               GitHub.find_pull_request("owner", "repo", "feature", "main")
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add `find_pull_request/4` to GitHub module to check for existing PRs before creating new ones
- Handle GitHub 422 "already exists" errors gracefully, returning `{:ok, :already_exists}`
- Rename `create_draft_pr` to `ensure_draft_pr` with idempotent check-then-create flow
- Harden JSON parsing in runner output with `is_list`/`is_map` guards
- Improve dev config defaults (`CITADEL_DEV_API_KEY` env var, `File.cwd!()` for project path)
- Add comprehensive tests for `find_pull_request/4` and updated `create_pull_request` error handling

## Test plan
- [ ] Verify `find_pull_request/4` returns existing PR URL when one exists
- [ ] Verify `find_pull_request/4` returns nil when no PR exists
- [ ] Verify `create_pull_request` returns `{:ok, :already_exists}` on duplicate PR
- [ ] Verify runner's `ensure_draft_pr` skips creation when PR already exists
- [ ] Run `mix test` in citadel_agent to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)