### PR TITLE
docs: clarify update_task tool to mention dependency tools

### DIFF
--- a/lib/citadel/tasks.ex
+++ b/lib/citadel/tasks.ex
@@ -17,7 +17,7 @@ defmodule Citadel.Tasks do
     end
 
     tool :update_task, Citadel.Tasks.Task, :update do
-      description "Updates an existing task's title, description, state, assignees, due_date, priority, or parent_task_id"
+      description "Updates an existing task's title, description, state, assignees, due_date, priority, or parent_task_id. To add or remove dependencies, use the create_task_dependency and delete_task_dependency tools instead."
     end
 
     tool :list_task_states, Citadel.Tasks.TaskState, :read do


### PR DESCRIPTION
## Summary
- Update `update_task` tool description to direct AI agents to use `create_task_dependency` and `delete_task_dependency` for managing dependencies instead of `update_task`

## Test plan
- [ ] Verify MCP tool descriptions reflect the updated guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)