### PR TITLE
feat: show task human_id with link in sidebar agent list

### DIFF
--- a/lib/citadel_web/live/agent_presence_hook.ex
+++ b/lib/citadel_web/live/agent_presence_hook.ex
@@ -7,6 +7,8 @@ defmodule CitadelWeb.AgentPresenceHook do
   import Phoenix.LiveView
   import Phoenix.Component
 
+  require Ash.Query
+
   alias CitadelWeb.AgentPresence
 
   def on_mount(:default, _params, _session, socket) do
@@ -17,7 +19,10 @@ defmodule CitadelWeb.AgentPresenceHook do
         topic = agent_topic(workspace.id)
         Phoenix.PubSub.subscribe(Citadel.PubSub, topic)
 
-        agents = presence_to_agents(AgentPresence.list(topic))
+        agents =
+          AgentPresence.list(topic)
+          |> presence_to_agents()
+          |> resolve_task_human_ids(workspace.id)
 
         socket
         |> assign(:agents, agents)
@@ -30,8 +35,14 @@ defmodule CitadelWeb.AgentPresenceHook do
   end
 
   defp handle_presence_info(%Phoenix.Socket.Broadcast{topic: "agents:" <> _}, socket) do
-    topic = agent_topic(socket.assigns.current_workspace.id)
-    agents = presence_to_agents(AgentPresence.list(topic))
+    workspace = socket.assigns.current_workspace
+    topic = agent_topic(workspace.id)
+
+    agents =
+      AgentPresence.list(topic)
+      |> presence_to_agents()
+      |> resolve_task_human_ids(workspace.id)
+
     {:halt, assign(socket, :agents, agents)}
   end
 
@@ -46,9 +57,33 @@ defmodule CitadelWeb.AgentPresenceHook do
         name: name,
         status: meta.status,
         current_task_id: meta.current_task_id,
+        current_task_human_id: nil,
         joined_at: meta.joined_at
       }
     end)
     |> Enum.sort_by(& &1.joined_at)
+  end
+
+  defp resolve_task_human_ids(agents, workspace_id) do
+    task_ids =
+      agents
+      |> Enum.map(& &1.current_task_id)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    if task_ids == [] do
+      agents
+    else
+      human_ids_by_id =
+        Citadel.Tasks.Task
+        |> Ash.Query.filter(id in ^task_ids)
+        |> Ash.Query.select([:id, :human_id])
+        |> Ash.read!(tenant: workspace_id, authorize?: false)
+        |> Map.new(&{&1.id, &1.human_id})
+
+      Enum.map(agents, fn agent ->
+        %{agent | current_task_human_id: Map.get(human_ids_by_id, agent.current_task_id)}
+      end)
+    end
   end
 end

--- a/lib/citadel_web/live/components/agent_status.ex
+++ b/lib/citadel_web/live/components/agent_status.ex
@@ -43,7 +43,13 @@ defmodule CitadelWeb.Components.AgentStatus do
             :if={agent.status == "working" && agent.current_task_id && agent.current_task_human_id}
             class="text-xs text-base-content/50 truncate"
           >
-            Working on <.link navigate={~p"/tasks/#{agent.current_task_human_id}"} class="underline hover:text-base-content/70">{agent.current_task_human_id}</.link>
+            Working on
+            <.link
+              navigate={~p"/tasks/#{agent.current_task_human_id}"}
+              class="underline hover:text-base-content/70"
+            >
+              {agent.current_task_human_id}
+            </.link>
           </span>
           <span
             :if={agent.status == "working" && agent.current_task_id && !agent.current_task_human_id}

--- a/lib/citadel_web/live/components/agent_status.ex
+++ b/lib/citadel_web/live/components/agent_status.ex
@@ -40,7 +40,13 @@ defmodule CitadelWeb.Components.AgentStatus do
         <div class="flex flex-col min-w-0 flex-1">
           <span class="text-sm font-medium text-base-content truncate">{agent.name}</span>
           <span
-            :if={agent.status == "working" && agent.current_task_id}
+            :if={agent.status == "working" && agent.current_task_id && agent.current_task_human_id}
+            class="text-xs text-base-content/50 truncate"
+          >
+            Working on <.link navigate={~p"/tasks/#{agent.current_task_human_id}"} class="underline hover:text-base-content/70">{agent.current_task_human_id}</.link>
+          </span>
+          <span
+            :if={agent.status == "working" && agent.current_task_id && !agent.current_task_human_id}
             class="text-xs text-base-content/50 truncate"
           >
             Working on task


### PR DESCRIPTION
When an agent is working on a task, resolve the task UUID to its human-readable ID (e.g. P-42) and display it as a clickable link in the sidebar. Falls back to "Working on task" if the task can't be resolved. Task lookups are batched to avoid N+1 queries.