### PR TITLE
fix(agent): move PR creation to after feature branch merge

### DIFF
--- a/citadel_agent/lib/citadel_agent/runner.ex
+++ b/citadel_agent/lib/citadel_agent/runner.ex
@@ -55,10 +55,11 @@ defmodule CitadelAgent.Runner do
     end
   end
 
-  defp maybe_merge_into_feature_branch(%{"parent_human_id" => parent_id} = _task, task_branch, project_path)
+  defp maybe_merge_into_feature_branch(%{"parent_human_id" => parent_id} = task, task_branch, project_path)
        when is_binary(parent_id) do
     feature_branch = "citadel/feature/#{parent_id}"
     merge_into_feature_branch(task_branch, feature_branch, project_path)
+    ensure_draft_pr(feature_branch, task, project_path)
   end
 
   defp maybe_merge_into_feature_branch(_task, _task_branch, _project_path), do: :ok
@@ -204,10 +205,6 @@ defmodule CitadelAgent.Runner do
               {:error, "Failed to create feature branch #{feature_branch}: #{output}"}
           end
       end
-
-    if result == :ok do
-      ensure_draft_pr(feature_branch, task, project_path)
-    end
 
     result
   end

--- a/citadel_agent/test/citadel_agent/runner_pr_test.exs
+++ b/citadel_agent/test/citadel_agent/runner_pr_test.exs
@@ -79,19 +79,27 @@ defmodule CitadelAgent.RunnerPRTest do
   end
 
   describe "PR creation on feature branch" do
-    test "creates draft PR when new feature branch is created", %{project_path: project_path} do
+    test "creates draft PR after merge into feature branch", %{project_path: project_path} do
       test_pid = self()
 
       Req.Test.stub(:github_pr, fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        send(test_pid, {:pr_created, conn, Jason.decode!(body)})
+        case conn.method do
+          "GET" ->
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(200, Jason.encode!([]))
 
-        conn
-        |> Plug.Conn.put_resp_content_type("application/json")
-        |> Plug.Conn.send_resp(
-          201,
-          Jason.encode!(%{"html_url" => "https://github.com/test-owner/test-repo/pull/1"})
-        )
+          "POST" ->
+            {:ok, body, conn} = Plug.Conn.read_body(conn)
+            send(test_pid, {:pr_created, conn, Jason.decode!(body)})
+
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(
+              201,
+              Jason.encode!(%{"html_url" => "https://github.com/test-owner/test-repo/pull/1"})
+            )
+        end
       end)
 
       task = %{
@@ -117,19 +125,39 @@ defmodule CitadelAgent.RunnerPRTest do
       project_path: project_path
     } do
       test_pid = self()
-      call_count = :counters.new(1, [:atomics])
+      pr_create_count = :counters.new(1, [:atomics])
 
       Req.Test.stub(:github_pr, fn conn ->
-        :counters.add(call_count, 1, 1)
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        send(test_pid, {:pr_created, Jason.decode!(body)})
+        case conn.method do
+          "GET" ->
+            # After first PR creation, return the existing PR
+            if :counters.get(pr_create_count, 1) > 0 do
+              conn
+              |> Plug.Conn.put_resp_content_type("application/json")
+              |> Plug.Conn.send_resp(
+                200,
+                Jason.encode!([
+                  %{"html_url" => "https://github.com/test-owner/test-repo/pull/1"}
+                ])
+              )
+            else
+              conn
+              |> Plug.Conn.put_resp_content_type("application/json")
+              |> Plug.Conn.send_resp(200, Jason.encode!([]))
+            end
 
-        conn
-        |> Plug.Conn.put_resp_content_type("application/json")
-        |> Plug.Conn.send_resp(
-          201,
-          Jason.encode!(%{"html_url" => "https://github.com/test-owner/test-repo/pull/1"})
-        )
+          "POST" ->
+            :counters.add(pr_create_count, 1, 1)
+            {:ok, body, conn} = Plug.Conn.read_body(conn)
+            send(test_pid, {:pr_created, Jason.decode!(body)})
+
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(
+              201,
+              Jason.encode!(%{"html_url" => "https://github.com/test-owner/test-repo/pull/1"})
+            )
+        end
       end)
 
       task1 = %{
@@ -149,14 +177,22 @@ defmodule CitadelAgent.RunnerPRTest do
       assert {:ok, _} = CitadelAgent.Runner.execute(task1, project_path)
       assert {:ok, _} = CitadelAgent.Runner.execute(task2, project_path)
 
-      assert :counters.get(call_count, 1) == 1
+      assert :counters.get(pr_create_count, 1) == 1
     end
 
     test "PR creation failure does not fail the overall task", %{project_path: project_path} do
       Req.Test.stub(:github_pr, fn conn ->
-        conn
-        |> Plug.Conn.put_resp_content_type("application/json")
-        |> Plug.Conn.send_resp(403, Jason.encode!(%{"message" => "Forbidden"}))
+        case conn.method do
+          "GET" ->
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(200, Jason.encode!([]))
+
+          "POST" ->
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(403, Jason.encode!(%{"message" => "Forbidden"}))
+        end
       end)
 
       task = %{
@@ -174,15 +210,23 @@ defmodule CitadelAgent.RunnerPRTest do
       test_pid = self()
 
       Req.Test.stub(:github_pr, fn conn ->
-        {:ok, body, conn} = Plug.Conn.read_body(conn)
-        send(test_pid, {:pr_created, Jason.decode!(body)})
+        case conn.method do
+          "GET" ->
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(200, Jason.encode!([]))
 
-        conn
-        |> Plug.Conn.put_resp_content_type("application/json")
-        |> Plug.Conn.send_resp(
-          201,
-          Jason.encode!(%{"html_url" => "https://github.com/test-owner/test-repo/pull/1"})
-        )
+          "POST" ->
+            {:ok, body, conn} = Plug.Conn.read_body(conn)
+            send(test_pid, {:pr_created, Jason.decode!(body)})
+
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(
+              201,
+              Jason.encode!(%{"html_url" => "https://github.com/test-owner/test-repo/pull/1"})
+            )
+        end
       end)
 
       task = %{


### PR DESCRIPTION
## Summary
- Moved draft PR creation from agent runner startup (`ensure_feature_branch`) to after the task branch is merged into the feature branch (`maybe_merge_into_feature_branch`)
- Fixes GitHub API 422 "No commits between main and feature branch" errors that occurred because PRs were created before any work was done
- Updated PR test stubs to properly handle GET/POST request routing for `find_pull_request` and `create_pull_request`

## Test plan
- [x] All 4 PR tests pass (`runner_pr_test.exs`)
- [x] All 9 feature branch tests pass (`runner_feature_branch_test.exs`)
- [x] Verified the pre-existing stale worktree test failure is unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)