### PR TITLE
feat: dependency-aware agent work enqueueing

### DIFF
--- a/lib/citadel/tasks/changes/maybe_enqueue_agent_work.ex
+++ b/lib/citadel/tasks/changes/maybe_enqueue_agent_work.ex
@@ -8,6 +8,7 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWork do
   def change(changeset, _opts, _context) do
     Ash.Changeset.after_action(changeset, fn _changeset, task ->
       maybe_create_work_item(task)
+      maybe_enqueue_unblocked_dependents(task)
       {:ok, task}
     end)
   end
@@ -21,8 +22,58 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWork do
   defp should_enqueue?(task) do
     task.agent_eligible == true &&
       workable_state?(task.task_state_id) &&
+      !blocked?(task) &&
       !active_run_exists?(task.id, task.workspace_id) &&
       !active_work_item_exists?(task.id, task.workspace_id)
+  end
+
+  defp blocked?(task) do
+    Citadel.Tasks.TaskDependency
+    |> Ash.Query.filter(task_id == ^task.id)
+    |> Ash.read!(authorize?: false)
+    |> Enum.any?(fn dep ->
+      dep_task =
+        Citadel.Tasks.Task
+        |> Ash.Query.filter(id == ^dep.depends_on_task_id)
+        |> Ash.read_one!(authorize?: false, tenant: task.workspace_id)
+
+      !complete_state?(dep_task.task_state_id)
+    end)
+  end
+
+  defp maybe_enqueue_unblocked_dependents(task) do
+    if complete_state?(task.task_state_id) do
+      enqueue_eligible_dependents(task)
+    end
+  end
+
+  defp enqueue_eligible_dependents(task) do
+    Citadel.Tasks.TaskDependency
+    |> Ash.Query.filter(depends_on_task_id == ^task.id)
+    |> Ash.read!(authorize?: false)
+    |> Enum.each(fn dep ->
+      dependent_task =
+        Citadel.Tasks.Task
+        |> Ash.Query.filter(id == ^dep.task_id)
+        |> Ash.read_one!(
+          authorize?: false,
+          tenant: task.workspace_id,
+          load: [dependencies: [task_state: [:is_complete]]]
+        )
+
+      if dependent_task do
+        maybe_create_work_item(dependent_task)
+      end
+    end)
+  end
+
+  defp complete_state?(task_state_id) do
+    case Citadel.Tasks.TaskState
+         |> Ash.Query.filter(id == ^task_state_id)
+         |> Ash.read_one(authorize?: false) do
+      {:ok, %{is_complete: true}} -> true
+      _ -> false
+    end
   end
 
   defp workable_state?(task_state_id) do

--- a/test/citadel/tasks/changes/maybe_enqueue_agent_work_test.exs
+++ b/test/citadel/tasks/changes/maybe_enqueue_agent_work_test.exs
@@ -249,6 +249,213 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
     end
   end
 
+  describe "dependency-blocked tasks" do
+    test "does not create work item when task has incomplete dependency on create", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state
+    } do
+      blocking_task =
+        Tasks.create_task!(
+          %{
+            title: "Blocker #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: false
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      dependent_task =
+        Tasks.create_task!(
+          %{
+            title: "Blocked Task #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: true,
+            dependencies: [blocking_task.id]
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      assert list_work_items_for_task(dependent_task.id, workspace.id) == []
+    end
+
+    test "does not create work item when task has incomplete dependency on update", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state
+    } do
+      blocking_task =
+        Tasks.create_task!(
+          %{
+            title: "Blocker #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: false
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      dependent_task =
+        Tasks.create_task!(
+          %{
+            title: "Blocked Task #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: false,
+            dependencies: [blocking_task.id]
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      Tasks.update_task!(dependent_task.id, %{agent_eligible: true},
+        actor: user,
+        tenant: workspace.id
+      )
+
+      assert list_work_items_for_task(dependent_task.id, workspace.id) == []
+    end
+
+    test "completing a blocking task enqueues work for unblocked dependent", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state,
+      done_state: done_state
+    } do
+      blocking_task =
+        Tasks.create_task!(
+          %{
+            title: "Blocker #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: false
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      dependent_task =
+        Tasks.create_task!(
+          %{
+            title: "Blocked Task #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: true,
+            dependencies: [blocking_task.id]
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      assert list_work_items_for_task(dependent_task.id, workspace.id) == []
+
+      Tasks.update_task!(blocking_task.id, %{task_state_id: done_state.id},
+        actor: user,
+        tenant: workspace.id
+      )
+
+      work_items = list_work_items_for_task(dependent_task.id, workspace.id)
+      assert length(work_items) == 1
+      assert hd(work_items).type == :new_task
+      assert hd(work_items).status == :pending
+    end
+
+    test "completing a blocking task does not enqueue dependent still blocked by another task", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state,
+      done_state: done_state
+    } do
+      blocker_a =
+        Tasks.create_task!(
+          %{
+            title: "Blocker A #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: false
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      blocker_b =
+        Tasks.create_task!(
+          %{
+            title: "Blocker B #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: false
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      dependent_task =
+        Tasks.create_task!(
+          %{
+            title: "Double Blocked #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: true,
+            dependencies: [blocker_a.id, blocker_b.id]
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      Tasks.update_task!(blocker_a.id, %{task_state_id: done_state.id},
+        actor: user,
+        tenant: workspace.id
+      )
+
+      assert list_work_items_for_task(dependent_task.id, workspace.id) == []
+    end
+
+    test "completing a blocking task does not enqueue non-agent-eligible dependent", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state,
+      done_state: done_state
+    } do
+      blocking_task =
+        Tasks.create_task!(
+          %{
+            title: "Blocker #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: false
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      dependent_task =
+        Tasks.create_task!(
+          %{
+            title: "Non-Agent Dep #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            workspace_id: workspace.id,
+            agent_eligible: false,
+            dependencies: [blocking_task.id]
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      Tasks.update_task!(blocking_task.id, %{task_state_id: done_state.id},
+        actor: user,
+        tenant: workspace.id
+      )
+
+      assert list_work_items_for_task(dependent_task.id, workspace.id) == []
+    end
+  end
+
   describe "task completion cancels work items" do
     test "cancels pending work items when task moves to complete state", %{
       user: user,


### PR DESCRIPTION
## Summary
- Blocked tasks (with incomplete dependencies) are no longer enqueued for agent work
- When a blocking task is completed, its dependent tasks are evaluated and enqueued if now eligible
- Reuses all existing guards (agent_eligible, workable state, no active runs/work items, not blocked by other deps)

## Test plan
- [x] Task with incomplete dependency is NOT enqueued on create
- [x] Task with incomplete dependency is NOT enqueued on update
- [x] Completing a blocking task enqueues work for a now-unblocked dependent
- [x] Completing a blocking task does NOT enqueue work for a dependent still blocked by another task
- [x] Completing a blocking task does NOT enqueue work for a non-agent-eligible dependent
- [x] All existing tests still pass
- [x] `mix ck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)