### PR TITLE
P-30

### DIFF
--- a/test/citadel_web/controllers/api/agent_controller_test.exs
+++ b/test/citadel_web/controllers/api/agent_controller_test.exs
@@ -278,6 +278,20 @@ defmodule CitadelWeb.Api.AgentControllerTest do
       assert data["task_state"]["name"] == new_state.name
     end
 
+    test "sets forge_pr on a task", ctx do
+      task = create_task(ctx.workspace, ctx.user, ctx.task_state)
+      pr_url = "https://github.com/test-owner/test-repo/pull/42"
+
+      conn =
+        patch(ctx.conn, ~p"/api/agent/tasks/#{task.id}", %{
+          "forge_pr" => pr_url
+        })
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert data["id"] == task.id
+      assert data["forge_pr"] == pr_url
+    end
+
     test "returns 404 for non-existent task", ctx do
       fake_id = Ash.UUID.generate()
 


### PR DESCRIPTION
## Summary

- After `CitadelAgent.Github.create_pull_request/1` succeeds, calls `PATCH /api/agent/tasks/:id` to set `forge_pr` on the task
- Always updates the top-level task (traverses to root if running on a subtask)
- Failure to set `forge_pr` logs a warning but does not fail the run

## Test plan

- [ ] Verify that after a successful agent run with PR creation, the task's `forge_pr` field is set to the correct PR URL
- [ ] Verify that when running on a subtask, `forge_pr` is set on the parent (root) task, not the subtask
- [ ] Verify that if the `forge_pr` API call fails, the run still completes successfully and a warning is logged
- [ ] Verify the PR URL is returned when querying the task via `GET /api/agent/tasks/:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)