### PR TITLE
fix: stop MCP clients from manually looking up workspace_id

### DIFF
--- a/lib/citadel/tasks/task.ex
+++ b/lib/citadel/tasks/task.ex
@@ -45,7 +45,6 @@ defmodule Citadel.Tasks.Task do
         :title,
         :description,
         :task_state_id,
-        :workspace_id,
         :parent_task_id,
         :project_id,
         :due_date,

--- a/lib/citadel/tasks/validations/assignees_workspace_members.ex
+++ b/lib/citadel/tasks/validations/assignees_workspace_members.ex
@@ -29,6 +29,7 @@ defmodule Citadel.Tasks.Validations.AssigneesWorkspaceMembers do
 
   defp get_workspace_id(changeset, context) do
     Ash.Changeset.get_attribute(changeset, :workspace_id) ||
+      context.tenant ||
       get_workspace_id_from_parent(changeset, context)
   end
 

--- a/test/citadel/tasks/agent_run_test.exs
+++ b/test/citadel/tasks/agent_run_test.exs
@@ -17,8 +17,7 @@ defmodule Citadel.Tasks.AgentRunTest do
       Tasks.create_task!(
         %{
           title: "Test Task #{System.unique_integer([:positive])}",
-          task_state_id: task_state.id,
-          workspace_id: workspace.id
+          task_state_id: task_state.id
         },
         actor: user,
         tenant: workspace.id
@@ -258,8 +257,7 @@ defmodule Citadel.Tasks.AgentRunTest do
         Tasks.create_task!(
           %{
             title: "Other Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id

--- a/test/citadel/tasks/agent_work_item_test.exs
+++ b/test/citadel/tasks/agent_work_item_test.exs
@@ -17,8 +17,7 @@ defmodule Citadel.Tasks.AgentWorkItemTest do
       Tasks.create_task!(
         %{
           title: "Test Task #{System.unique_integer([:positive])}",
-          task_state_id: task_state.id,
-          workspace_id: workspace.id
+          task_state_id: task_state.id
         },
         actor: user,
         tenant: workspace.id

--- a/test/citadel/tasks/changes/claim_next_task_test.exs
+++ b/test/citadel/tasks/changes/claim_next_task_test.exs
@@ -53,7 +53,6 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           %{
             title: "Claimable #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,
@@ -91,8 +90,7 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
         Tasks.create_task!(
           %{
             title: "Dep Task #{System.unique_integer([:positive])}",
-            task_state_id: todo_state.id,
-            workspace_id: workspace.id
+            task_state_id: todo_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -103,7 +101,6 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           %{
             title: "Blocked Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true,
             dependencies: [dep_task.id]
           },
@@ -126,7 +123,6 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           %{
             title: "Low #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true,
             priority: :low
           },
@@ -139,7 +135,6 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           %{
             title: "High #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true,
             priority: :high
           },
@@ -163,7 +158,6 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           %{
             title: "Lifecycle #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,
@@ -197,7 +191,6 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           %{
             title: "Fail #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,
@@ -231,7 +224,6 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           %{
             title: "Cancel #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,

--- a/test/citadel/tasks/changes/maybe_enqueue_agent_work_test.exs
+++ b/test/citadel/tasks/changes/maybe_enqueue_agent_work_test.exs
@@ -61,7 +61,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Agent Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,
@@ -84,7 +83,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Non-Agent Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -105,7 +103,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Done Task #{System.unique_integer([:positive])}",
             task_state_id: done_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,
@@ -126,7 +123,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Review Task #{System.unique_integer([:positive])}",
             task_state_id: in_review_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,
@@ -149,7 +145,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Toggle Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -175,7 +170,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Review to Progress #{System.unique_integer([:positive])}",
             task_state_id: in_review_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,
@@ -203,7 +197,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "No Dup Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,
@@ -230,7 +223,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Active Run Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -260,7 +252,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocker #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -272,7 +263,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocked Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true,
             dependencies: [blocking_task.id]
           },
@@ -293,7 +283,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocker #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -305,7 +294,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocked Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false,
             dependencies: [blocking_task.id]
           },
@@ -332,7 +320,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocker #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -344,7 +331,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocked Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true,
             dependencies: [blocking_task.id]
           },
@@ -376,7 +362,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocker A #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -388,7 +373,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocker B #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -400,7 +384,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Double Blocked #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true,
             dependencies: [blocker_a.id, blocker_b.id]
           },
@@ -427,7 +410,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Blocker #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false
           },
           actor: user,
@@ -439,7 +421,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Non-Agent Dep #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: false,
             dependencies: [blocking_task.id]
           },
@@ -468,7 +449,6 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Complete Task #{System.unique_integer([:positive])}",
             task_state_id: todo_state.id,
-            workspace_id: workspace.id,
             agent_eligible: true
           },
           actor: user,

--- a/test/citadel/tasks/claim_next_task_test.exs
+++ b/test/citadel/tasks/claim_next_task_test.exs
@@ -47,7 +47,6 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
       %{
         title: "Eligible Task #{System.unique_integer([:positive])}",
         task_state_id: ctx.todo_state.id,
-        workspace_id: ctx.workspace.id,
         agent_eligible: true,
         priority: Keyword.get(opts, :priority, :medium)
       },
@@ -161,7 +160,6 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
         %{
           title: "Completed Task #{System.unique_integer([:positive])}",
           task_state_id: ctx.done_state.id,
-          workspace_id: ctx.workspace.id,
           agent_eligible: true
         },
         actor: ctx.user,
@@ -184,7 +182,6 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
         %{
           title: "In Review Task #{System.unique_integer([:positive])}",
           task_state_id: ctx.in_review_state.id,
-          workspace_id: ctx.workspace.id,
           agent_eligible: true
         },
         actor: ctx.user,
@@ -207,8 +204,7 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
         Tasks.create_task!(
           %{
             title: "Dependency #{System.unique_integer([:positive])}",
-            task_state_id: ctx.todo_state.id,
-            workspace_id: ctx.workspace.id
+            task_state_id: ctx.todo_state.id
           },
           actor: ctx.user,
           tenant: ctx.workspace.id
@@ -237,8 +233,7 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
         Tasks.create_task!(
           %{
             title: "Completed Dep #{System.unique_integer([:positive])}",
-            task_state_id: ctx.done_state.id,
-            workspace_id: ctx.workspace.id
+            task_state_id: ctx.done_state.id
           },
           actor: ctx.user,
           tenant: ctx.workspace.id
@@ -265,7 +260,6 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
         %{
           title: "Not Eligible #{System.unique_integer([:positive])}",
           task_state_id: ctx.todo_state.id,
-          workspace_id: ctx.workspace.id,
           agent_eligible: false
         },
         actor: ctx.user,

--- a/test/citadel/tasks/get_task_details_test.exs
+++ b/test/citadel/tasks/get_task_details_test.exs
@@ -28,7 +28,6 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
             title: "Test Task #{System.unique_integer([:positive])}",
             description: "A detailed description",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             priority: :high,
             due_date: ~D[2026-04-01]
           },
@@ -60,8 +59,7 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -72,7 +70,6 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
           %{
             title: "Child Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             parent_task_id: parent.id
           },
           actor: user,
@@ -98,8 +95,7 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -110,7 +106,6 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
           %{
             title: "Sub Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             parent_task_id: parent.id
           },
           actor: user,
@@ -137,7 +132,6 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
           %{
             title: "Assigned Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             assignees: [user.id]
           },
           actor: user,
@@ -162,8 +156,7 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
         Tasks.create_task!(
           %{
             title: "Dependency Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -174,7 +167,6 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
           %{
             title: "Blocked Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             dependencies: [dep_task.id]
           },
           actor: user,
@@ -212,8 +204,7 @@ defmodule Citadel.Tasks.GetTaskDetailsTest do
         Tasks.create_task!(
           %{
             title: "Tenant Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id

--- a/test/citadel/tasks/mcp_task_dependency_test.exs
+++ b/test/citadel/tasks/mcp_task_dependency_test.exs
@@ -148,7 +148,6 @@ defmodule Citadel.Tasks.McpTaskDependencyTest do
                  %{
                    title: "Task with dependencies",
                    task_state_id: todo_state.id,
-                   workspace_id: workspace.id,
                    dependencies: [dep_task_1.id, dep_task_2.id]
                  },
                  actor: user,
@@ -173,7 +172,6 @@ defmodule Citadel.Tasks.McpTaskDependencyTest do
                  %{
                    title: "Task without dependencies",
                    task_state_id: todo_state.id,
-                   workspace_id: workspace.id,
                    dependencies: []
                  },
                  actor: user,
@@ -193,8 +191,7 @@ defmodule Citadel.Tasks.McpTaskDependencyTest do
                Tasks.create_task(
                  %{
                    title: "Task no deps arg",
-                   task_state_id: todo_state.id,
-                   workspace_id: workspace.id
+                   task_state_id: todo_state.id
                  },
                  actor: user,
                  tenant: workspace.id

--- a/test/citadel/tasks/request_changes_test.exs
+++ b/test/citadel/tasks/request_changes_test.exs
@@ -29,8 +29,7 @@ defmodule Citadel.Tasks.RequestChangesTest do
       Tasks.create_task!(
         %{
           title: "Test Task #{System.unique_integer([:positive])}",
-          task_state_id: in_review_state.id,
-          workspace_id: workspace.id
+          task_state_id: in_review_state.id
         },
         actor: user,
         tenant: workspace.id
@@ -115,8 +114,7 @@ defmodule Citadel.Tasks.RequestChangesTest do
         Tasks.create_task!(
           %{
             title: "Todo Task #{System.unique_integer([:positive])}",
-            task_state_id: todo_state.id,
-            workspace_id: workspace.id
+            task_state_id: todo_state.id
           },
           actor: user,
           tenant: workspace.id

--- a/test/citadel/tasks/task_activity_interfaces_test.exs
+++ b/test/citadel/tasks/task_activity_interfaces_test.exs
@@ -17,8 +17,7 @@ defmodule Citadel.Tasks.TaskActivityInterfacesTest do
       Tasks.create_task!(
         %{
           title: "Test Task #{System.unique_integer([:positive])}",
-          task_state_id: task_state.id,
-          workspace_id: workspace.id
+          task_state_id: task_state.id
         },
         actor: user,
         tenant: workspace.id
@@ -140,8 +139,7 @@ defmodule Citadel.Tasks.TaskActivityInterfacesTest do
         Tasks.create_task!(
           %{
             title: "Other Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id

--- a/test/citadel/tasks/task_activity_test.exs
+++ b/test/citadel/tasks/task_activity_test.exs
@@ -17,8 +17,7 @@ defmodule Citadel.Tasks.TaskActivityTest do
       Tasks.create_task!(
         %{
           title: "Test Task #{System.unique_integer([:positive])}",
-          task_state_id: task_state.id,
-          workspace_id: workspace.id
+          task_state_id: task_state.id
         },
         actor: user,
         tenant: workspace.id

--- a/test/citadel/tasks/task_multitenancy_test.exs
+++ b/test/citadel/tasks/task_multitenancy_test.exs
@@ -41,7 +41,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace1.id,
               task_state_id: task_state.id
             ],
             actor: owner1,
@@ -67,7 +66,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace1.id,
               task_state_id: task_state.id
             ],
             actor: owner1,
@@ -117,7 +115,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace1.id,
               task_state_id: task_state.id
             ],
             actor: owner1,
@@ -129,7 +126,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace2.id,
               task_state_id: task_state.id
             ],
             actor: owner2,
@@ -160,7 +156,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace1.id,
               task_state_id: task_state.id
             ],
             actor: owner1,
@@ -172,7 +167,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace2.id,
               task_state_id: task_state.id
             ],
             actor: owner2,
@@ -202,7 +196,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace1.id,
               task_state_id: task_state.id
             ],
             actor: owner1,
@@ -233,7 +226,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace1.id,
               task_state_id: task_state.id
             ],
             actor: owner1,
@@ -269,7 +261,6 @@ defmodule Citadel.Tasks.TaskMultitenancyTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id
             ],
             actor: owner,

--- a/test/citadel/tasks/task_pubsub_test.exs
+++ b/test/citadel/tasks/task_pubsub_test.exs
@@ -29,7 +29,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner,
             tenant: workspace.id
           )
@@ -52,7 +52,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner,
             tenant: workspace.id
           )
@@ -81,7 +81,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner,
             tenant: workspace.id
           )
@@ -110,7 +110,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner,
             tenant: workspace.id
           )
@@ -142,7 +142,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       parent_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner,
             tenant: workspace.id
           )
@@ -154,7 +154,6 @@ defmodule Citadel.Tasks.TaskPubSubTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               parent_task_id: parent_task.id
             ],
@@ -180,7 +179,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       parent_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner,
             tenant: workspace.id
           )
@@ -190,7 +189,6 @@ defmodule Citadel.Tasks.TaskPubSubTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               parent_task_id: parent_task.id
             ],
@@ -223,7 +221,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       parent_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner,
             tenant: workspace.id
           )
@@ -233,7 +231,6 @@ defmodule Citadel.Tasks.TaskPubSubTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               parent_task_id: parent_task.id
             ],
@@ -273,7 +270,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       _task2 =
         generate(
           task(
-            [workspace_id: workspace2.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner2,
             tenant: workspace2.id
           )
@@ -292,7 +289,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       task1 =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id, title: "Task 1"],
+            [task_state_id: task_state.id, title: "Task 1"],
             actor: owner,
             tenant: workspace.id
           )
@@ -310,7 +307,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       task2 =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id, title: "Task 2"],
+            [task_state_id: task_state.id, title: "Task 2"],
             actor: owner,
             tenant: workspace.id
           )
@@ -338,7 +335,6 @@ defmodule Citadel.Tasks.TaskPubSubTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               title: "Test Task",
               description: "Description",
@@ -372,7 +368,7 @@ defmodule Citadel.Tasks.TaskPubSubTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: owner,
             tenant: workspace.id
           )

--- a/test/citadel/tasks/task_summary_test.exs
+++ b/test/citadel/tasks/task_summary_test.exs
@@ -20,7 +20,6 @@ defmodule Citadel.Tasks.TaskSummaryTest do
         %{
           title: "Test Task #{System.unique_integer([:positive])}",
           task_state_id: task_state.id,
-          workspace_id: workspace.id,
           priority: :high,
           due_date: ~D[2026-04-01]
         },
@@ -99,8 +98,7 @@ defmodule Citadel.Tasks.TaskSummaryTest do
       Tasks.create_task!(
         %{
           title: "Other Workspace Task #{System.unique_integer([:positive])}",
-          task_state_id: task_state.id,
-          workspace_id: other_workspace.id
+          task_state_id: task_state.id
         },
         actor: other_user,
         tenant: other_workspace.id
@@ -151,8 +149,7 @@ defmodule Citadel.Tasks.TaskSummaryTest do
         %{
           title: "Another Task #{System.unique_integer([:positive])}",
           description: needle,
-          task_state_id: task_state.id,
-          workspace_id: workspace.id
+          task_state_id: task_state.id
         },
         actor: user,
         tenant: workspace.id

--- a/test/citadel/tasks/task_test.exs
+++ b/test/citadel/tasks/task_test.exs
@@ -25,8 +25,7 @@ defmodule Citadel.Tasks.TaskTest do
       attrs = %{
         title: "Test Task #{System.unique_integer([:positive])}",
         description: "A test task",
-        task_state_id: task_state.id,
-        workspace_id: workspace.id
+        task_state_id: task_state.id
       }
 
       assert task = Tasks.create_task!(attrs, actor: user, tenant: workspace.id)
@@ -46,7 +45,6 @@ defmodule Citadel.Tasks.TaskTest do
         title: "Test Task #{System.unique_integer([:positive])}",
         description: "A test task",
         task_state_id: task_state.id,
-        workspace_id: workspace.id,
         assignees: [user.id]
       }
 
@@ -63,8 +61,7 @@ defmodule Citadel.Tasks.TaskTest do
     } do
       attrs = %{
         title: "Minimal Task #{System.unique_integer([:positive])}",
-        task_state_id: task_state.id,
-        workspace_id: workspace.id
+        task_state_id: task_state.id
       }
 
       assert task = Tasks.create_task!(attrs, actor: user, tenant: workspace.id)
@@ -78,8 +75,7 @@ defmodule Citadel.Tasks.TaskTest do
       task_state: task_state
     } do
       attrs = %{
-        task_state_id: task_state.id,
-        workspace_id: workspace.id
+        task_state_id: task_state.id
       }
 
       assert_raise Ash.Error.Invalid, fn ->
@@ -104,8 +100,7 @@ defmodule Citadel.Tasks.TaskTest do
         })
 
       attrs = %{
-        title: "Task Without State #{System.unique_integer([:positive])}",
-        workspace_id: workspace.id
+        title: "Task Without State #{System.unique_integer([:positive])}"
       }
 
       task = Tasks.create_task!(attrs, actor: user, tenant: workspace.id)
@@ -116,8 +111,7 @@ defmodule Citadel.Tasks.TaskTest do
     test "raises error when actor is missing", %{workspace: workspace, task_state: task_state} do
       attrs = %{
         title: "Missing User #{System.unique_integer([:positive])}",
-        task_state_id: task_state.id,
-        workspace_id: workspace.id
+        task_state_id: task_state.id
       }
 
       assert_raise Ash.Error.Invalid, fn ->
@@ -136,8 +130,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task 1 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -147,8 +140,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task 2 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -173,8 +165,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Other User Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: other_user,
           tenant: workspace.id
@@ -184,8 +175,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "User Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -218,8 +208,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task State 1 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -229,8 +218,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task State 2 #{System.unique_integer([:positive])}",
-            task_state_id: other_state.id,
-            workspace_id: workspace.id
+            task_state_id: other_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -252,8 +240,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task with Relations #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -285,8 +272,7 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Original Title #{System.unique_integer([:positive])}",
             description: "Original description",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -319,8 +305,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -344,8 +329,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Protected Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -368,8 +352,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -392,8 +375,7 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Original Title #{System.unique_integer([:positive])}",
             description: "Original description",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -431,8 +413,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -465,8 +446,7 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Original #{System.unique_integer([:positive])}",
             description: "Original desc",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -501,8 +481,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Protected Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -525,8 +504,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Valid Title #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -546,8 +524,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -580,8 +557,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -603,8 +579,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -634,8 +609,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -664,8 +638,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -695,8 +668,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -740,8 +712,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Top Level Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -787,8 +758,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -819,8 +789,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -849,8 +818,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Grandparent #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -890,8 +858,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "To Delete #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -915,8 +882,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Protected Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -938,8 +904,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -971,8 +936,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Other Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -995,8 +959,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1018,8 +981,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Top Level 1 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1029,8 +991,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Top Level 2 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1076,8 +1037,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1111,8 +1071,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1142,8 +1101,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1173,8 +1131,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1193,8 +1150,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1213,8 +1169,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1232,8 +1187,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task 1 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1243,8 +1197,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task 2 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1254,8 +1207,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task 3 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1284,8 +1236,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task in WS1 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace1.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace1.id
@@ -1295,8 +1246,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task in WS2 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace2.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace2.id
@@ -1320,8 +1270,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1356,7 +1305,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             human_id: "CUSTOM-999"
           },
           actor: user,
@@ -1376,8 +1324,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Find Me #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1408,8 +1355,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Secret Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1431,8 +1377,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1451,7 +1396,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Urgent Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             priority: :urgent
           },
           actor: user,
@@ -1471,7 +1415,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             priority: :low
           },
           actor: user,
@@ -1493,7 +1436,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             priority: :invalid
           },
           actor: user,
@@ -1516,7 +1458,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             due_date: due_date
           },
           actor: user,
@@ -1535,8 +1476,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1554,8 +1494,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1580,8 +1519,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1603,7 +1541,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             due_date: future_date
           },
           actor: user,
@@ -1626,7 +1563,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             due_date: past_date
           },
           actor: user,
@@ -1649,7 +1585,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             due_date: today
           },
           actor: user,
@@ -1671,8 +1606,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1694,7 +1628,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             due_date: future_date
           },
           actor: user,
@@ -1717,7 +1650,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             due_date: past_date
           },
           actor: user,
@@ -1740,7 +1672,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             due_date: today
           },
           actor: user,
@@ -1763,7 +1694,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             assignees: [user.id]
           },
           actor: user,
@@ -1788,7 +1718,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             assignees: [user.id, other_user.id]
           },
           actor: user,
@@ -1815,8 +1744,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1849,7 +1777,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             assignees: [user.id, other_user.id]
           },
           actor: user,
@@ -1880,7 +1807,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             assignees: [non_member.id]
           },
           actor: user,
@@ -1899,7 +1825,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             assignees: [user.id]
           },
           actor: user,
@@ -1924,7 +1849,6 @@ defmodule Citadel.Tasks.TaskTest do
           %{
             title: "Task #{System.unique_integer([:positive])}",
             task_state_id: task_state.id,
-            workspace_id: workspace.id,
             assignees: [member.id]
           },
           actor: user,
@@ -1947,8 +1871,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent 1 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1958,8 +1881,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent 2 #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -1996,8 +1918,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -2034,8 +1955,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Task #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -2058,8 +1978,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Parent #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -2093,8 +2012,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Grandparent #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -2139,8 +2057,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "New Parent #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id
@@ -2150,8 +2067,7 @@ defmodule Citadel.Tasks.TaskTest do
         Tasks.create_task!(
           %{
             title: "Top Level #{System.unique_integer([:positive])}",
-            task_state_id: task_state.id,
-            workspace_id: workspace.id
+            task_state_id: task_state.id
           },
           actor: user,
           tenant: workspace.id

--- a/test/citadel_web/controllers/api/agent_claim_concurrency_test.exs
+++ b/test/citadel_web/controllers/api/agent_claim_concurrency_test.exs
@@ -33,7 +33,7 @@ defmodule CitadelWeb.Api.AgentClaimConcurrencyTest do
   end
 
   defp create_task(workspace, user, task_state, attrs \\ []) do
-    defaults = [workspace_id: workspace.id, task_state_id: task_state.id, agent_eligible: true]
+    defaults = [task_state_id: task_state.id, agent_eligible: true]
     generate(task(Keyword.merge(defaults, attrs), actor: user, tenant: workspace.id))
   end
 

--- a/test/citadel_web/controllers/api/agent_controller_test.exs
+++ b/test/citadel_web/controllers/api/agent_controller_test.exs
@@ -38,7 +38,7 @@ defmodule CitadelWeb.Api.AgentControllerTest do
   end
 
   defp create_task(workspace, user, task_state, attrs \\ []) do
-    defaults = [workspace_id: workspace.id, task_state_id: task_state.id, agent_eligible: true]
+    defaults = [task_state_id: task_state.id, agent_eligible: true]
     generate(task(Keyword.merge(defaults, attrs), actor: user, tenant: workspace.id))
   end
 

--- a/test/citadel_web/live/dashboard_live/index_test.exs
+++ b/test/citadel_web/live/dashboard_live/index_test.exs
@@ -80,7 +80,7 @@ defmodule CitadelWeb.DashboardLive.IndexTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id, title: "Test Task"],
+            [task_state_id: task_state.id, title: "Test Task"],
             actor: user,
             tenant: workspace.id
           )
@@ -113,7 +113,7 @@ defmodule CitadelWeb.DashboardLive.IndexTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id, title: "Test Task"],
+            [task_state_id: task_state.id, title: "Test Task"],
             actor: user,
             tenant: workspace.id
           )
@@ -144,7 +144,6 @@ defmodule CitadelWeb.DashboardLive.IndexTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: todo_state.id,
               title: "Priority Test Task",
               priority: :high
@@ -190,7 +189,7 @@ defmodule CitadelWeb.DashboardLive.IndexTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id, title: "Test Task"],
+            [task_state_id: task_state.id, title: "Test Task"],
             actor: user,
             tenant: workspace.id
           )

--- a/test/citadel_web/live/task_live/show_activity_test.exs
+++ b/test/citadel_web/live/task_live/show_activity_test.exs
@@ -21,7 +21,7 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
     task =
       generate(
         task(
-          [workspace_id: workspace.id, task_state_id: task_state.id, title: "Task With Activity"],
+          [task_state_id: task_state.id, title: "Task With Activity"],
           actor: user,
           tenant: workspace.id
         )

--- a/test/citadel_web/live/task_live/show_test.exs
+++ b/test/citadel_web/live/task_live/show_test.exs
@@ -15,7 +15,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id, title: "Test Task"],
+            [task_state_id: task_state.id, title: "Test Task"],
             actor: user,
             tenant: workspace.id
           )
@@ -52,7 +52,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id, title: "Original Title"],
+            [task_state_id: task_state.id, title: "Original Title"],
             actor: user,
             tenant: workspace.id
           )
@@ -62,7 +62,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               title: "Sub Task",
               parent_task_id: task.id
@@ -168,7 +167,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -203,7 +202,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               due_date: ~D[2025-01-15]
             ],
@@ -238,7 +236,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               title: "Sub Task for Due Date",
               parent_task_id: task.id
@@ -271,7 +268,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id, priority: :low],
+            [task_state_id: task_state.id, priority: :low],
             actor: user,
             tenant: workspace.id
           )
@@ -329,7 +326,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               title: "Sub Task for Priority",
               parent_task_id: task.id
@@ -362,7 +358,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: task_state.id],
+            [task_state_id: task_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -422,7 +418,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               title: "Sub Task for Assignee",
               parent_task_id: task.id
@@ -461,7 +456,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -512,7 +507,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: todo_state.id,
               title: "Sub Task for State",
               parent_task_id: task.id
@@ -546,7 +540,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id, title: "Parent Task"],
+            [task_state_id: todo_state.id, title: "Parent Task"],
             actor: user,
             tenant: workspace.id
           )
@@ -556,7 +550,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: todo_state.id,
               title: "Draggable Sub Task",
               parent_task_id: task.id
@@ -635,7 +628,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: owner_workspace.id, task_state_id: task_state.id, title: "Owner Task"],
+            [task_state_id: task_state.id, title: "Owner Task"],
             actor: owner,
             tenant: owner_workspace.id
           )
@@ -661,7 +654,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id, title: "Main Task"],
+            [task_state_id: todo_state.id, title: "Main Task"],
             actor: user,
             tenant: workspace.id
           )
@@ -692,7 +685,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependency_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id, title: "Dependency Task"],
+            [task_state_id: todo_state.id, title: "Dependency Task"],
             actor: user,
             tenant: workspace.id
           )
@@ -730,7 +723,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       task_b =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -764,7 +757,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependency_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -800,7 +793,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependency_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -828,7 +821,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       complete_dependency =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: done_state.id],
+            [task_state_id: done_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -856,7 +849,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependency_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -891,7 +884,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependency_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -941,7 +934,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependency_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -988,7 +981,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependent_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -1018,7 +1011,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependency_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -1048,7 +1041,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       dependency_task =
         generate(
           task(
-            [workspace_id: workspace.id, task_state_id: todo_state.id],
+            [task_state_id: todo_state.id],
             actor: user,
             tenant: workspace.id
           )
@@ -1109,7 +1102,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               title: "Agent Task",
               agent_eligible: true
@@ -1139,7 +1131,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               title: "Non-Agent Task",
               agent_eligible: false
@@ -1228,7 +1219,6 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         generate(
           task(
             [
-              workspace_id: workspace.id,
               task_state_id: task_state.id,
               title: "Cancel Test Task",
               agent_eligible: true


### PR DESCRIPTION
## Summary
- Removed `workspace_id` from the task create action's `accept` list since it's already inferred from the API key via `SetTenantFromApiKey` plug and Ash multitenancy
- The `get_current_workspace` tool description was already updated on main to no longer prompt clients to "retrieve the current workspace_id"
- Together these changes prevent MCP clients (like Claude Code) from unnecessarily calling `get_current_workspace` before every task creation

## Test plan
- [ ] Verify creating tasks via MCP still works (workspace_id set automatically from tenant)
- [ ] Verify creating sub-tasks still inherits workspace from parent via `InheritParentWorkspace` change
- [ ] Confirm MCP clients no longer call `get_current_workspace` before creating tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)