### PR TITLE
chore: rebrand Citadel to Pyllar in UI, emails, and legal docs

### DIFF
--- a/lib/citadel_web/components/layouts.ex
+++ b/lib/citadel_web/components/layouts.ex
@@ -298,7 +298,7 @@ defmodule CitadelWeb.Layouts do
                   <.icon name="hero-building-library" class="size-4" />
                 </div>
               </div>
-              <span class="text-xl font-bold tracking-tight">Citadel</span>
+              <span class="text-xl font-bold tracking-tight">Pyllar</span>
             </.link>
 
             <div class="hidden md:flex items-center gap-8">

--- a/lib/citadel_web/components/layouts/root.html.heex
+++ b/lib/citadel_web/components/layouts/root.html.heex
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title default="Citadel" suffix=" · Citadel">
+    <.live_title default="Pyllar" suffix=" · Pyllar">
       {assigns[:page_title]}
     </.live_title>
 
@@ -22,7 +22,7 @@
     <meta property="og:url" content={assigns[:og_url] || "https://citadel.app"} />
     <meta
       property="og:title"
-      content={assigns[:page_title] || "Citadel - AI-Powered Task Management"}
+      content={assigns[:page_title] || "Pyllar - AI-Powered Task Management"}
     />
     <meta
       property="og:description"
@@ -32,12 +32,12 @@
       }
     />
     <meta property="og:image" content={assigns[:og_image] || "/images/og-image.png"} />
-    <meta property="og:site_name" content="Citadel" />
+    <meta property="og:site_name" content="Pyllar" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content={assigns[:page_title] || "Citadel - AI-Powered Task Management"}
+      content={assigns[:page_title] || "Pyllar - AI-Powered Task Management"}
     />
     <meta
       name="twitter:description"

--- a/lib/citadel_web/emails/base_layout.mjml.eex
+++ b/lib/citadel_web/emails/base_layout.mjml.eex
@@ -14,7 +14,7 @@
     <mj-section background-color="#ffffff" padding="20px">
       <mj-column>
         <mj-text font-size="24px" font-weight="bold" color="#1a1a1a">
-          Citadel
+          Pyllar
         </mj-text>
       </mj-column>
     </mj-section>
@@ -26,7 +26,7 @@
     <mj-section padding="20px">
       <mj-column>
         <mj-text font-size="12px" color="#999999" align="center">
-          <a href="<%= @app_url %>" class="footer-link">Open Citadel</a>
+          <a href="<%= @app_url %>" class="footer-link">Open Pyllar</a>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/lib/citadel_web/emails/email_confirmation.mjml.eex
+++ b/lib/citadel_web/emails/email_confirmation.mjml.eex
@@ -5,7 +5,7 @@
     </mj-text>
 
     <mj-text padding-top="20px">
-      Welcome to Citadel! Please confirm your email address to complete your registration.
+      Welcome to Pyllar! Please confirm your email address to complete your registration.
     </mj-text>
 
     <mj-button href="<%= @confirm_url %>" padding-top="24px">

--- a/lib/citadel_web/emails/password_reset.mjml.eex
+++ b/lib/citadel_web/emails/password_reset.mjml.eex
@@ -5,7 +5,7 @@
     </mj-text>
 
     <mj-text padding-top="20px">
-      You requested a password reset for your Citadel account. Click the button below to set a new password.
+      You requested a password reset for your Pyllar account. Click the button below to set a new password.
     </mj-text>
 
     <mj-button href="<%= @reset_url %>" padding-top="24px">

--- a/lib/citadel_web/emails/workspace_invitation.mjml.eex
+++ b/lib/citadel_web/emails/workspace_invitation.mjml.eex
@@ -6,7 +6,7 @@
 
     <mj-text padding-top="20px">
       <strong><%= @inviter_email %></strong> has invited you to collaborate on
-      <strong><%= @workspace_name %></strong> in Citadel.
+      <strong><%= @workspace_name %></strong> in Pyllar.
     </mj-text>
 
     <mj-button href="<%= @accept_url %>" padding-top="24px">

--- a/lib/citadel_web/live/landing_live.ex
+++ b/lib/citadel_web/live/landing_live.ex
@@ -58,7 +58,7 @@ defmodule CitadelWeb.LandingLive do
           </h1>
 
           <p class="text-lg sm:text-xl text-base-content/60 max-w-2xl mx-auto mb-10 leading-relaxed">
-            AI-native project management for developers. Describe what you're building—Citadel creates the plan.
+            AI-native project management for developers. Describe what you're building—Pyllar creates the plan.
           </p>
 
           <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">

--- a/priv/static/legal/privacy.md
+++ b/priv/static/legal/privacy.md
@@ -8,9 +8,9 @@
 
 ## Introduction
 
-Citadel ("we," "us," or "our") respects your privacy and is committed to protecting your personal data. This Privacy Policy explains how we collect, use, share, and protect your information when you use our task management and AI chat application ("the Service").
+Pyllar ("we," "us," or "our") respects your privacy and is committed to protecting your personal data. This Privacy Policy explains how we collect, use, share, and protect your information when you use our task management and AI chat application ("the Service").
 
-By using Citadel, you agree to the collection and use of information as described in this policy. If you do not agree, please do not use the Service.
+By using Pyllar, you agree to the collection and use of information as described in this policy. If you do not agree, please do not use the Service.
 
 ---
 
@@ -268,7 +268,7 @@ We will respond within 45 days.
 
 ## 8. Children's Privacy
 
-Citadel is not intended for children under 18 years of age. We do not knowingly collect personal information from children. If we learn we have collected data from a child, we will delete it promptly.
+Pyllar is not intended for children under 18 years of age. We do not knowingly collect personal information from children. If we learn we have collected data from a child, we will delete it promptly.
 
 ---
 
@@ -331,4 +331,4 @@ For your convenience, here's a summary of our privacy practices:
 
 ---
 
-*By using Citadel, you acknowledge that you have read and understood this Privacy Policy.*
+*By using Pyllar, you acknowledge that you have read and understood this Privacy Policy.*

--- a/priv/static/legal/terms.md
+++ b/priv/static/legal/terms.md
@@ -8,15 +8,15 @@
 
 ## 1. Agreement to Terms
 
-By accessing or using Citadel ("the Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you may not use the Service.
+By accessing or using Pyllar ("the Service"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you may not use the Service.
 
-These Terms constitute a legally binding agreement between you and Citadel ("we," "us," or "our"). Please read them carefully.
+These Terms constitute a legally binding agreement between you and Pyllar ("we," "us," or "our"). Please read them carefully.
 
 ---
 
 ## 2. Description of Service
 
-Citadel is a task management and AI-powered chat application that provides:
+Pyllar is a task management and AI-powered chat application that provides:
 
 - **Workspace-based task management** - Create, organize, and track tasks within collaborative workspaces
 - **AI-powered chat** - Conversational AI assistance for productivity and task management
@@ -30,7 +30,7 @@ The Service may be updated, modified, or enhanced over time. We reserve the righ
 
 ### 3.1 Account Creation
 
-To use Citadel, you must:
+To use Pyllar, you must:
 
 - Sign in using Google OAuth authentication
 - Provide accurate and complete information
@@ -70,7 +70,7 @@ Content you create within a workspace (tasks, conversations, messages) is visibl
 
 ### 5.1 AI-Generated Content
 
-Citadel provides AI-powered features including chat assistance and task parsing. Regarding AI-generated content:
+Pyllar provides AI-powered features including chat assistance and task parsing. Regarding AI-generated content:
 
 - **No Warranty**: AI responses are provided "as-is" without any warranty of accuracy, completeness, or fitness for any particular purpose
 - **Not Professional Advice**: AI responses do not constitute professional, legal, medical, financial, or any other specialized advice
@@ -101,7 +101,7 @@ You may not use AI features to:
 
 ### 6.1 Credit System
 
-Citadel uses a credit system for AI features:
+Pyllar uses a credit system for AI features:
 
 - Users receive a monthly allocation of credits
 - Credits are consumed when using AI chat features
@@ -164,7 +164,7 @@ You agree not to:
 
 ### 9.1 Our Intellectual Property
 
-Citadel and its content (excluding user content) are protected by copyright, trademark, and other intellectual property laws. You may not copy, modify, or distribute our content without permission.
+Pyllar and its content (excluding user content) are protected by copyright, trademark, and other intellectual property laws. You may not copy, modify, or distribute our content without permission.
 
 ### 9.2 Your Content
 
@@ -182,7 +182,7 @@ Any feedback or suggestions you provide may be used by us without obligation to 
 
 ## 10. Third-Party Services
 
-Citadel integrates with third-party services:
+Pyllar integrates with third-party services:
 
 | Service | Purpose |
 |---------|---------|
@@ -228,7 +228,7 @@ This limitation applies regardless of the theory of liability (contract, tort, o
 
 ## 14. Indemnification
 
-You agree to indemnify and hold harmless Citadel and its officers, directors, employees, and agents from any claims, damages, losses, or expenses (including reasonable attorneys' fees) arising from:
+You agree to indemnify and hold harmless Pyllar and its officers, directors, employees, and agents from any claims, damages, losses, or expenses (including reasonable attorneys' fees) arising from:
 
 - Your use of the Service
 - Your violation of these Terms
@@ -290,7 +290,7 @@ Any disputes arising from these Terms or the Service shall be resolved through:
 
 ### 18.1 Entire Agreement
 
-These Terms, along with our Privacy Policy, constitute the entire agreement between you and Citadel.
+These Terms, along with our Privacy Policy, constitute the entire agreement between you and Pyllar.
 
 ### 18.2 Severability
 
@@ -315,4 +315,4 @@ If you have questions about these Terms, please contact us:
 
 ---
 
-*By using Citadel, you acknowledge that you have read, understood, and agree to these Terms of Service.*
+*By using Pyllar, you acknowledge that you have read, understood, and agree to these Terms of Service.*


### PR DESCRIPTION
## Summary

- Updates page titles, OG/Twitter metadata in root layout
- Updates navbar brand name in app layout
- Updates all email templates (base layout, confirmation, password reset, workspace invitation)
- Updates landing page hero copy
- Updates legal documents (privacy policy and terms of service)

## Test plan

- [ ] Visually verify brand name in nav, page title, and emails
- [ ] Confirm legal doc pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)