### PR TITLE
fix: correct Pro plan price on landing page from $12 to $19/month

### DIFF
--- a/lib/citadel_web/live/landing_live.ex
+++ b/lib/citadel_web/live/landing_live.ex
@@ -456,7 +456,7 @@ defmodule CitadelWeb.LandingLive do
                 </div>
 
                 <div class="mb-6">
-                  <span class="text-4xl font-bold">$12</span>
+                  <span class="text-4xl font-bold">$19</span>
                   <span class="text-base-content/60 ml-1">/per month</span>
                 </div>
 

--- a/test/citadel_web/live/landing_live_test.exs
+++ b/test/citadel_web/live/landing_live_test.exs
@@ -38,7 +38,7 @@ defmodule CitadelWeb.LandingLiveTest do
       assert html =~ "Free"
       assert html =~ "Pro"
       assert html =~ "$0"
-      assert html =~ "$12"
+      assert html =~ "$19"
     end
 
     test "displays footer with links" do


### PR DESCRIPTION
The landing page hardcoded $12/month for the Pro plan, but the billing page correctly shows $19/month. This mismatch was trust-breaking and could cause confusion or chargebacks.