### PR TITLE
P-154

### DIFF
--- a/citadel_agent/lib/citadel_agent/runner.ex
+++ b/citadel_agent/lib/citadel_agent/runner.ex
@@ -236,9 +236,10 @@ defmodule CitadelAgent.Runner do
 
             Logger.info("Pushed #{feature_branch} to origin")
 
+            pr_title = generate_pr_title(task, project_path, pr_title_id)
             {:ok, pr_body} = generate_pr_description(task, project_path)
 
-            case CitadelAgent.GitHub.create_pull_request(owner, repo, feature_branch, "main", pr_title_id, pr_body) do
+            case CitadelAgent.GitHub.create_pull_request(owner, repo, feature_branch, "main", pr_title, pr_body) do
               {:ok, :already_exists} ->
                 Logger.info("PR already exists for #{feature_branch} (detected during creation)")
                 nil
@@ -439,6 +440,42 @@ defmodule CitadelAgent.Runner do
   end
 
   defp maybe_commit_and_push(_claude_result, _task, _worktree_path, _branch_name), do: :ok
+
+  def generate_pr_title(task, project_path, pr_title_id) do
+    title = task["title"] || ""
+    description = task["description"] || ""
+
+    prompt = """
+    Generate a short, descriptive pull request title (under 60 characters) for the following task. \
+    Output ONLY the title text, nothing else. Do not use any tools or make any code changes. \
+    Do not include the task ID — just the descriptive title.
+
+    Task: #{title}
+
+    #{description}
+    """
+
+    case run_claude_cli(String.trim(prompt),
+           working_dir: project_path,
+           label: "pr-title:#{task["human_id"]}",
+           timeout: @commit_stall_timeout,
+           model: "sonnet"
+         ) do
+      {:ok, %{exit_code: 0, output: output}} ->
+        case extract_text_from_stream_json(output) do
+          nil -> pr_title_id
+          text -> "#{pr_title_id}: #{String.trim(text)}"
+        end
+
+      {:ok, %{exit_code: _code}} ->
+        Logger.warning("PR title generation failed, using fallback")
+        pr_title_id
+
+      {:error, reason} ->
+        Logger.warning("PR title generation failed: #{inspect(reason)}, using fallback")
+        pr_title_id
+    end
+  end
 
   def generate_pr_description(task, project_path) do
     title = task["title"] || ""


### PR DESCRIPTION
## Summary

- Add `generate_pr_title/3` to `CitadelAgent.Runner` that uses the Claude CLI to generate a short, descriptive title from the task's title and description
- Update `ensure_draft_pr/3` to call `generate_pr_title/3` and produce PR titles in the format `P-42: <descriptive title>` instead of just the bare task ID
- Falls back gracefully to the task ID alone if title generation fails

## Implementation Details

The new `generate_pr_title/3` follows the same pattern as the existing `generate_pr_description/2`:
- Prompts Claude (model: `sonnet`) for a title under 60 characters based on the task title and description
- Calls `run_claude_cli/2` with label `"pr-title:#{task["human_id"]}"`
- Parses output with `extract_text_from_stream_json/1`
- Returns `"#{pr_title_id}: #{generated_title}"` on success, falls back to `pr_title_id` on any failure

Supports both subtasks (uses `parent_human_id`) and top-level tasks (uses `human_id`).

## Test Plan

- [ ] Verify that newly created draft PRs have titles in the format `P-XX: <short title>`
- [ ] Confirm fallback behavior: simulate a Claude CLI failure and verify the PR title falls back to just the task ID
- [ ] Confirm behavior is consistent for both subtasks and top-level tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)