### PR TITLE
feat: fetch plan prices from Stripe instead of hardcoding them

### DIFF
--- a/lib/citadel/application.ex
+++ b/lib/citadel/application.ex
@@ -22,6 +22,7 @@ defmodule Citadel.Application do
       {Phoenix.PubSub, name: Citadel.PubSub},
       CitadelWeb.AgentPresence,
       Citadel.Settings.FeatureFlagCache,
+      Citadel.Billing.PriceCache,
       # Start a worker by calling: Citadel.Worker.start_link(arg)
       # {Citadel.Worker, arg},
       # Start to serve requests, typically the last entry

--- a/lib/citadel/billing/price_cache.ex
+++ b/lib/citadel/billing/price_cache.ex
@@ -1,0 +1,103 @@
+defmodule Citadel.Billing.PriceCache do
+  @moduledoc """
+  ETS-backed cache for Stripe plan prices with a periodic TTL refresh.
+
+  On startup the GenServer fetches live unit_amount values from Stripe for
+  each configured price ID. If Stripe is unreachable, or a price ID is not
+  yet configured (e.g. in dev/test), it falls back to the hardcoded defaults
+  in `Citadel.Billing.Plan`. The cache is refreshed automatically every hour.
+
+  ## Usage
+
+      Citadel.Billing.PriceCache.get_plan_prices()
+      #=> %{pro_monthly_cents: 1900, pro_annual_cents: 19000,
+      #=>   pro_seat_monthly_cents: 500, pro_seat_annual_cents: 5000}
+  """
+
+  use GenServer
+  require Logger
+
+  alias Citadel.Billing.Plan
+
+  @table_name :billing_price_cache
+  @ttl_ms :timer.hours(1)
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Returns cached plan prices. Falls back to Plan defaults if the cache is
+  not yet populated or the ETS table is unavailable.
+  """
+  @spec get_plan_prices() :: map()
+  def get_plan_prices do
+    case :ets.lookup(@table_name, :prices) do
+      [{:prices, prices}] -> prices
+      [] -> fallback_prices()
+    end
+  rescue
+    ArgumentError -> fallback_prices()
+  end
+
+  @impl true
+  def init(_opts) do
+    :ets.new(@table_name, [:set, :protected, :named_table, read_concurrency: true])
+    send(self(), :refresh)
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:refresh, state) do
+    prices = fetch_prices()
+    :ets.insert(@table_name, {:prices, prices})
+    Process.send_after(self(), :refresh, @ttl_ms)
+    {:noreply, state}
+  end
+
+  defp fetch_prices do
+    defaults = fallback_prices()
+
+    %{
+      pro_monthly_cents:
+        fetch_price_or_default(Plan.stripe_price_id(:pro, :monthly), defaults.pro_monthly_cents),
+      pro_annual_cents:
+        fetch_price_or_default(Plan.stripe_price_id(:pro, :annual), defaults.pro_annual_cents),
+      pro_seat_monthly_cents:
+        fetch_price_or_default(
+          Plan.stripe_seat_price_id(:pro, :monthly),
+          defaults.pro_seat_monthly_cents
+        ),
+      pro_seat_annual_cents:
+        fetch_price_or_default(
+          Plan.stripe_seat_price_id(:pro, :annual),
+          defaults.pro_seat_annual_cents
+        )
+    }
+  end
+
+  defp fetch_price_or_default(nil, default), do: default
+
+  defp fetch_price_or_default(price_id, default) do
+    case Stripe.Price.retrieve(price_id) do
+      {:ok, %{unit_amount: amount}} when is_integer(amount) ->
+        amount
+
+      {:ok, _} ->
+        default
+
+      {:error, error} ->
+        Logger.warning("Failed to fetch Stripe price #{price_id}: #{inspect(error)}")
+        default
+    end
+  end
+
+  defp fallback_prices do
+    %{
+      pro_monthly_cents: Plan.base_price_cents(:pro, :monthly),
+      pro_annual_cents: Plan.base_price_cents(:pro, :annual),
+      pro_seat_monthly_cents: Plan.per_member_price_cents(:pro, :monthly),
+      pro_seat_annual_cents: Plan.per_member_price_cents(:pro, :annual)
+    }
+  end
+end

--- a/lib/citadel_web/live/billing_live/index.ex
+++ b/lib/citadel_web/live/billing_live/index.ex
@@ -8,6 +8,7 @@ defmodule CitadelWeb.BillingLive.Index do
   alias Citadel.Accounts
   alias Citadel.Billing
   alias Citadel.Billing.Plan
+  alias Citadel.Billing.PriceCache
 
   def mount(_params, _session, socket) do
     organization_id = socket.assigns.current_workspace.organization_id
@@ -20,6 +21,7 @@ defmodule CitadelWeb.BillingLive.Index do
     balance = get_balance(organization_id, user)
     memberships = get_memberships(organization_id, user)
     plan = Plan.get(subscription.tier)
+    plan_prices = PriceCache.get_plan_prices()
 
     {:ok,
      socket
@@ -28,7 +30,8 @@ defmodule CitadelWeb.BillingLive.Index do
      |> assign(:subscription, subscription)
      |> assign(:balance, balance)
      |> assign(:memberships, memberships)
-     |> assign(:plan, plan)}
+     |> assign(:plan, plan)
+     |> assign(:plan_prices, plan_prices)}
   end
 
   def handle_params(params, _uri, socket) do
@@ -179,12 +182,12 @@ defmodule CitadelWeb.BillingLive.Index do
       else
         additional_members = max(member_count - 1, 0)
 
-        base_monthly = Plan.base_price_cents(:pro, :monthly) |> div(100)
-        per_seat_monthly = Plan.per_member_price_cents(:pro, :monthly) |> div(100)
+        base_monthly = div(assigns.plan_prices.pro_monthly_cents, 100)
+        per_seat_monthly = div(assigns.plan_prices.pro_seat_monthly_cents, 100)
         total_monthly = base_monthly + additional_members * per_seat_monthly
 
-        base_annual = Plan.base_price_cents(:pro, :annual) |> div(100)
-        per_seat_annual = Plan.per_member_price_cents(:pro, :annual) |> div(100)
+        base_annual = div(assigns.plan_prices.pro_annual_cents, 100)
+        per_seat_annual = div(assigns.plan_prices.pro_seat_annual_cents, 100)
         total_annual = base_annual + additional_members * per_seat_annual
         monthly_equivalent = div(total_annual, 12)
 
@@ -212,7 +215,7 @@ defmodule CitadelWeb.BillingLive.Index do
           >
             <div class="text-xs text-base-content/60 uppercase tracking-wide mb-1">Monthly</div>
             <div class="text-3xl font-bold mb-1">
-              ${Plan.base_price_cents(:pro, :monthly) |> div(100)}
+              ${div(@plan_prices.pro_monthly_cents, 100)}
             </div>
             <div class="text-xs text-base-content/60 mb-4">per month</div>
             <div class="btn btn-ghost btn-sm w-full pointer-events-none">Choose Monthly</div>
@@ -231,9 +234,11 @@ defmodule CitadelWeb.BillingLive.Index do
             </div>
             <div class="text-xs text-base-content/60 uppercase tracking-wide mb-1">Annual</div>
             <div class="text-3xl font-bold mb-1">
-              ${Plan.base_price_cents(:pro, :annual) |> div(100)}
+              ${div(@plan_prices.pro_annual_cents, 100)}
             </div>
-            <div class="text-xs text-base-content/60 mb-4">per year (≈ $16/mo)</div>
+            <div class="text-xs text-base-content/60 mb-4">
+              per year (≈ ${div(@plan_prices.pro_annual_cents, 1200)}/mo)
+            </div>
             <div class="btn btn-primary btn-sm w-full pointer-events-none">Choose Annual</div>
           </button>
         </form>

--- a/lib/citadel_web/live/landing_live.ex
+++ b/lib/citadel_web/live/landing_live.ex
@@ -3,6 +3,8 @@ defmodule CitadelWeb.LandingLive do
 
   use CitadelWeb, :live_view
 
+  alias Citadel.Billing.PriceCache
+
   on_mount {CitadelWeb.LiveUserAuth, :live_user_optional}
 
   def mount(_params, _session, socket) do
@@ -12,7 +14,8 @@ defmodule CitadelWeb.LandingLive do
      |> assign(
        :meta_description,
        "AI-native project management for developers. Turn complex features into actionable tasks. Manage everything from your coding assistant."
-     )}
+     )
+     |> assign(:plan_prices, PriceCache.get_plan_prices())}
   end
 
   def render(assigns) do
@@ -22,7 +25,7 @@ defmodule CitadelWeb.LandingLive do
       <.problem_section />
       <.solution_section />
       <.features_section />
-      <.pricing_section />
+      <.pricing_section plan_prices={@plan_prices} />
       <.cta_section />
       <.footer_section />
     </Layouts.marketing>
@@ -377,6 +380,8 @@ defmodule CitadelWeb.LandingLive do
   end
 
   defp pricing_section(assigns) do
+    assigns = assign(assigns, :pro_monthly_price, div(assigns.plan_prices.pro_monthly_cents, 100))
+
     ~H"""
     <section id="pricing" class="py-24 lg:py-32 relative overflow-hidden">
       <div class="absolute inset-0 pointer-events-none">
@@ -456,7 +461,7 @@ defmodule CitadelWeb.LandingLive do
                 </div>
 
                 <div class="mb-6">
-                  <span class="text-4xl font-bold">$12</span>
+                  <span class="text-4xl font-bold">${@pro_monthly_price}</span>
                   <span class="text-base-content/60 ml-1">/per month</span>
                 </div>
 


### PR DESCRIPTION
Adds Citadel.Billing.PriceCache, an ETS-backed GenServer that fetches unit_amount values from Stripe once per hour and serves them to any caller without hitting the Stripe API on every request.

Both the landing page and billing page now read prices from the cache at mount time, so the displayed price always reflects what is configured in Stripe. If Stripe is unreachable or a price ID is not configured (e.g. dev/test), the cache falls back to the hardcoded defaults in Plan, so the pages still render correctly.

The annual plan's "≈ $X/mo" figure on the billing upgrade card is now computed dynamically from the cached annual price rather than being a hardcoded $16.