### PR TITLE
feat: prevent child tasks from depending on their parent task

### DIFF
--- a/lib/citadel/tasks/task_dependency.ex
+++ b/lib/citadel/tasks/task_dependency.ex
@@ -155,6 +155,7 @@ defmodule Citadel.Tasks.TaskDependency do
 
   validations do
     validate Citadel.Tasks.Validations.NoCircularDependency
+    validate Citadel.Tasks.Validations.NoParentDependency
   end
 
   attributes do

--- a/lib/citadel/tasks/validations/no_parent_dependency.ex
+++ b/lib/citadel/tasks/validations/no_parent_dependency.ex
@@ -1,0 +1,32 @@
+defmodule Citadel.Tasks.Validations.NoParentDependency do
+  @moduledoc """
+  Validates that a task dependency does not point to the task's own parent.
+  """
+  use Ash.Resource.Validation
+
+  @impl true
+  def init(opts), do: {:ok, opts}
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    task_id = Ash.Changeset.get_attribute(changeset, :task_id)
+    depends_on_task_id = Ash.Changeset.get_attribute(changeset, :depends_on_task_id)
+
+    if is_nil(task_id) or is_nil(depends_on_task_id) do
+      :ok
+    else
+      require Ash.Query
+
+      case Citadel.Tasks.Task
+           |> Ash.Query.filter(id == ^task_id)
+           |> Ash.Query.select([:parent_task_id])
+           |> Ash.read_one(authorize?: false, tenant: changeset.tenant) do
+        {:ok, %{parent_task_id: ^depends_on_task_id}} ->
+          {:error, field: :depends_on_task_id, message: "a task cannot depend on its parent task"}
+
+        _ ->
+          :ok
+      end
+    end
+  end
+end

--- a/test/citadel/tasks/task_dependency_test.exs
+++ b/test/citadel/tasks/task_dependency_test.exs
@@ -49,6 +49,32 @@ defmodule Citadel.Tasks.TaskDependencyTest do
       assert dependency.depends_on_task_id == task_b.id
     end
 
+    test "prevents dependency on parent task", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state
+    } do
+      parent_task =
+        generate(task([task_state_id: todo_state.id], actor: user, tenant: workspace.id))
+
+      child_task =
+        generate(
+          task([task_state_id: todo_state.id, parent_task_id: parent_task.id],
+            actor: user,
+            tenant: workspace.id
+          )
+        )
+
+      assert {:error, %Ash.Error.Invalid{} = error} =
+               Tasks.create_task_dependency(
+                 %{task_id: child_task.id, depends_on_task_id: parent_task.id},
+                 actor: user,
+                 tenant: workspace.id
+               )
+
+      assert Exception.message(error) =~ "a task cannot depend on its parent task"
+    end
+
     test "prevents self-referential dependency", %{
       user: user,
       workspace: workspace,


### PR DESCRIPTION
Adds NoParentDependency validation to TaskDependency to reject dependencies where a child task would be blocked by its own parent, which creates a logically inconsistent state.