### PR TITLE
P-157

### DIFF
--- a/lib/citadel/tasks/changes/claim_next_task.ex
+++ b/lib/citadel/tasks/changes/claim_next_task.ex
@@ -72,6 +72,7 @@ defmodule Citadel.Tasks.Changes.ClaimNextTask do
         where: wi.status == :pending,
         where: ts.is_complete != true,
         where: ts.name != "In Review",
+        where: ts.name != "Backlog",
         where: not exists(active_runs_subquery),
         where: not exists(incomplete_deps_subquery),
         order_by: ^[desc: priority_order, asc: dynamic([work_item: wi], wi.inserted_at)],

--- a/lib/citadel/tasks/changes/maybe_enqueue_agent_work.ex
+++ b/lib/citadel/tasks/changes/maybe_enqueue_agent_work.ex
@@ -82,6 +82,7 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWork do
          |> Ash.read_one(authorize?: false) do
       {:ok, %{is_complete: true}} -> false
       {:ok, %{name: "In Review"}} -> false
+      {:ok, %{name: "Backlog"}} -> false
       {:ok, %{}} -> true
       _ -> false
     end

--- a/test/citadel/tasks/changes/claim_next_task_test.exs
+++ b/test/citadel/tasks/changes/claim_next_task_test.exs
@@ -9,6 +9,17 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
     user = generate(user())
     workspace = generate(workspace([], actor: user))
 
+    backlog_state =
+      case Citadel.Tasks.TaskState
+           |> Ash.Query.filter(name == "Backlog")
+           |> Ash.read_one(authorize?: false) do
+        {:ok, nil} ->
+          Tasks.create_task_state!(%{name: "Backlog", order: 0, is_complete: false})
+
+        {:ok, state} ->
+          state
+      end
+
     todo_state =
       Tasks.create_task_state!(%{
         name: "To Do #{System.unique_integer([:positive])}",
@@ -39,6 +50,7 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
      workspace: workspace,
      todo_state: todo_state,
      in_review_state: in_review_state,
+     backlog_state: backlog_state,
      done_state: done_state}
   end
 
@@ -107,6 +119,34 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           actor: user,
           tenant: workspace.id
         )
+
+      assert_raise Ash.Error.Invalid, ~r/no tasks available/, fn ->
+        Tasks.claim_next_task!(actor: user, tenant: workspace.id)
+      end
+    end
+
+    test "skips work items for tasks in Backlog state", %{
+      user: user,
+      workspace: workspace,
+      backlog_state: backlog_state
+    } do
+      task =
+        Tasks.create_task!(
+          %{
+            title: "Backlog Task #{System.unique_integer([:positive])}",
+            task_state_id: backlog_state.id,
+            agent_eligible: false
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      Citadel.Tasks.AgentWorkItem
+      |> Ash.Changeset.for_create(:create, %{type: :new_task, task_id: task.id},
+        authorize?: false,
+        tenant: workspace.id
+      )
+      |> Ash.create!()
 
       assert_raise Ash.Error.Invalid, ~r/no tasks available/, fn ->
         Tasks.claim_next_task!(actor: user, tenant: workspace.id)

--- a/test/citadel/tasks/changes/maybe_enqueue_agent_work_test.exs
+++ b/test/citadel/tasks/changes/maybe_enqueue_agent_work_test.exs
@@ -9,6 +9,17 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
     user = generate(user())
     workspace = generate(workspace([], actor: user))
 
+    backlog_state =
+      case Citadel.Tasks.TaskState
+           |> Ash.Query.filter(name == "Backlog")
+           |> Ash.read_one(authorize?: false) do
+        {:ok, nil} ->
+          Tasks.create_task_state!(%{name: "Backlog", order: 0, is_complete: false})
+
+        {:ok, state} ->
+          state
+      end
+
     todo_state =
       Tasks.create_task_state!(%{
         name: "To Do #{System.unique_integer([:positive])}",
@@ -47,6 +58,7 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
      todo_state: todo_state,
      in_progress_state: in_progress_state,
      in_review_state: in_review_state,
+     backlog_state: backlog_state,
      done_state: done_state}
   end
 
@@ -113,6 +125,26 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
       assert work_items == []
     end
 
+    test "does not create work item when task state is Backlog", %{
+      user: user,
+      workspace: workspace,
+      backlog_state: backlog_state
+    } do
+      task =
+        Tasks.create_task!(
+          %{
+            title: "Backlog Task #{System.unique_integer([:positive])}",
+            task_state_id: backlog_state.id,
+            agent_eligible: true
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      work_items = list_work_items_for_task(task.id, workspace.id)
+      assert work_items == []
+    end
+
     test "does not create work item when task state is In Review", %{
       user: user,
       workspace: workspace,
@@ -154,6 +186,34 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
       assert list_work_items_for_task(task.id, workspace.id) == []
 
       Tasks.update_task!(task.id, %{agent_eligible: true}, actor: user, tenant: workspace.id)
+
+      work_items = list_work_items_for_task(task.id, workspace.id)
+      assert length(work_items) == 1
+    end
+
+    test "creates work item when state changed from Backlog to workable", %{
+      user: user,
+      workspace: workspace,
+      backlog_state: backlog_state,
+      todo_state: todo_state
+    } do
+      task =
+        Tasks.create_task!(
+          %{
+            title: "Backlog to Todo #{System.unique_integer([:positive])}",
+            task_state_id: backlog_state.id,
+            agent_eligible: true
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      assert list_work_items_for_task(task.id, workspace.id) == []
+
+      Tasks.update_task!(task.id, %{task_state_id: todo_state.id},
+        actor: user,
+        tenant: workspace.id
+      )
 
       work_items = list_work_items_for_task(task.id, workspace.id)
       assert length(work_items) == 1


### PR DESCRIPTION
## Summary

- Exclude Backlog tasks from agent work item creation in `MaybeEnqueueAgentWork`
- Filter out Backlog tasks from the agent claim query in `ClaimNextTask`

## Changes

- Added `"Backlog"` to the non-workable states in `workable_state?/1` so agent-eligible tasks in Backlog no longer generate work items
- Added a `ts.name != "Backlog"` filter to the claim query to prevent agent runners from picking up Backlog tasks
- Added test coverage for both paths

## Behavior

Previously, tasks with `agent_eligible: true` would create work items regardless of state, including Backlog. Now only tasks in actionable states (e.g., Todo, In Progress) generate work items. Moving a task from Backlog to an actionable state still triggers work item creation as expected.