### PR TITLE
P-157

### DIFF
--- a/lib/citadel/tasks/changes/claim_next_task.ex
+++ b/lib/citadel/tasks/changes/claim_next_task.ex
@@ -72,6 +72,7 @@ defmodule Citadel.Tasks.Changes.ClaimNextTask do
         where: wi.status == :pending,
         where: ts.is_complete != true,
         where: ts.name != "In Review",
+        where: ts.name != "Backlog",
         where: not exists(active_runs_subquery),
         where: not exists(incomplete_deps_subquery),
         order_by: ^[desc: priority_order, asc: dynamic([work_item: wi], wi.inserted_at)],

--- a/lib/citadel/tasks/changes/maybe_enqueue_agent_work.ex
+++ b/lib/citadel/tasks/changes/maybe_enqueue_agent_work.ex
@@ -82,6 +82,7 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWork do
          |> Ash.read_one(authorize?: false) do
       {:ok, %{is_complete: true}} -> false
       {:ok, %{name: "In Review"}} -> false
+      {:ok, %{name: "Backlog"}} -> false
       {:ok, %{}} -> true
       _ -> false
     end

--- a/test/citadel/tasks/changes/claim_next_task_test.exs
+++ b/test/citadel/tasks/changes/claim_next_task_test.exs
@@ -27,6 +27,17 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           state
       end
 
+    backlog_state =
+      case Citadel.Tasks.TaskState
+           |> Ash.Query.filter(name == "Backlog")
+           |> Ash.read_one(authorize?: false) do
+        {:ok, nil} ->
+          Tasks.create_task_state!(%{name: "Backlog", order: 0, is_complete: false})
+
+        {:ok, state} ->
+          state
+      end
+
     done_state =
       Tasks.create_task_state!(%{
         name: "Done #{System.unique_integer([:positive])}",
@@ -39,6 +50,7 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
      workspace: workspace,
      todo_state: todo_state,
      in_review_state: in_review_state,
+     backlog_state: backlog_state,
      done_state: done_state}
   end
 
@@ -107,6 +119,64 @@ defmodule Citadel.Tasks.Changes.ClaimNextTaskTest do
           actor: user,
           tenant: workspace.id
         )
+
+      assert_raise Ash.Error.Invalid, ~r/no tasks available/, fn ->
+        Tasks.claim_next_task!(actor: user, tenant: workspace.id)
+      end
+    end
+
+    test "skips work items for tasks in Backlog state", %{
+      user: user,
+      workspace: workspace,
+      backlog_state: backlog_state
+    } do
+      _backlog_task =
+        Tasks.create_task!(
+          %{
+            title: "Backlog Task #{System.unique_integer([:positive])}",
+            task_state_id: backlog_state.id,
+            agent_eligible: true
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      # Backlog prevents work item creation, but even if one existed via
+      # a state transition, the claim query should still exclude it.
+      # Since no work item is created for Backlog tasks, claiming should fail.
+      assert_raise Ash.Error.Invalid, ~r/no tasks available/, fn ->
+        Tasks.claim_next_task!(actor: user, tenant: workspace.id)
+      end
+    end
+
+    test "skips Backlog tasks even when work item exists from prior state", %{
+      user: user,
+      workspace: workspace,
+      todo_state: todo_state,
+      backlog_state: backlog_state
+    } do
+      task =
+        Tasks.create_task!(
+          %{
+            title: "Regressed Task #{System.unique_integer([:positive])}",
+            task_state_id: todo_state.id,
+            agent_eligible: true
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      work_items =
+        Citadel.Tasks.AgentWorkItem
+        |> Ash.Query.filter(task_id == ^task.id)
+        |> Ash.read!(authorize?: false, tenant: workspace.id)
+
+      assert length(work_items) == 1
+
+      Tasks.update_task!(task.id, %{task_state_id: backlog_state.id},
+        actor: user,
+        tenant: workspace.id
+      )
 
       assert_raise Ash.Error.Invalid, ~r/no tasks available/, fn ->
         Tasks.claim_next_task!(actor: user, tenant: workspace.id)

--- a/test/citadel/tasks/changes/maybe_enqueue_agent_work_test.exs
+++ b/test/citadel/tasks/changes/maybe_enqueue_agent_work_test.exs
@@ -34,6 +34,17 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           state
       end
 
+    backlog_state =
+      case Citadel.Tasks.TaskState
+           |> Ash.Query.filter(name == "Backlog")
+           |> Ash.read_one(authorize?: false) do
+        {:ok, nil} ->
+          Tasks.create_task_state!(%{name: "Backlog", order: 0, is_complete: false})
+
+        {:ok, state} ->
+          state
+      end
+
     done_state =
       Tasks.create_task_state!(%{
         name: "Done #{System.unique_integer([:positive])}",
@@ -47,6 +58,7 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
      todo_state: todo_state,
      in_progress_state: in_progress_state,
      in_review_state: in_review_state,
+     backlog_state: backlog_state,
      done_state: done_state}
   end
 
@@ -103,6 +115,26 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
           %{
             title: "Done Task #{System.unique_integer([:positive])}",
             task_state_id: done_state.id,
+            agent_eligible: true
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      work_items = list_work_items_for_task(task.id, workspace.id)
+      assert work_items == []
+    end
+
+    test "does not create work item when task state is Backlog", %{
+      user: user,
+      workspace: workspace,
+      backlog_state: backlog_state
+    } do
+      task =
+        Tasks.create_task!(
+          %{
+            title: "Backlog Task #{System.unique_integer([:positive])}",
+            task_state_id: backlog_state.id,
             agent_eligible: true
           },
           actor: user,
@@ -179,6 +211,34 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWorkTest do
       assert list_work_items_for_task(task.id, workspace.id) == []
 
       Tasks.update_task!(task.id, %{task_state_id: in_progress_state.id},
+        actor: user,
+        tenant: workspace.id
+      )
+
+      work_items = list_work_items_for_task(task.id, workspace.id)
+      assert length(work_items) == 1
+    end
+
+    test "creates work item when state changed from Backlog to workable", %{
+      user: user,
+      workspace: workspace,
+      backlog_state: backlog_state,
+      todo_state: todo_state
+    } do
+      task =
+        Tasks.create_task!(
+          %{
+            title: "Backlog to Todo #{System.unique_integer([:positive])}",
+            task_state_id: backlog_state.id,
+            agent_eligible: true
+          },
+          actor: user,
+          tenant: workspace.id
+        )
+
+      assert list_work_items_for_task(task.id, workspace.id) == []
+
+      Tasks.update_task!(task.id, %{task_state_id: todo_state.id},
         actor: user,
         tenant: workspace.id
       )


### PR DESCRIPTION
## Summary

- Exclude tasks in the **Backlog** state from creating agent work items by adding a `"Backlog"` pattern match to `workable_state?/1` in `MaybeEnqueueAgentWork`

## Problem

Agent-eligible tasks in the Backlog state were incorrectly creating work items. The `workable_state?/1` function only excluded complete states and "In Review", leaving Backlog tasks unguarded.

## Solution

Added `{:ok, %{name: "Backlog"}} -> false` as a pattern match clause in `workable_state?/1`, before the catch-all `{:ok, %{}} -> true` clause. This mirrors the existing "In Review" exclusion pattern.

Tasks moved from Backlog to a workable state (e.g., Todo) will still generate work items naturally via the existing update hook.

## Test Plan

- [ ] Verify that creating an agent-eligible task in Backlog state does **not** create a work item
- [ ] Verify that creating an agent-eligible task in Todo/In Progress states **does** create a work item
- [ ] Verify that updating a task from Backlog → Todo triggers work item creation