### PR TITLE
P-161

### DIFF
--- a/citadel_agent/lib/citadel_agent/socket.ex
+++ b/citadel_agent/lib/citadel_agent/socket.ex
@@ -59,9 +59,9 @@ defmodule CitadelAgent.Socket do
   end
 
   @impl true
-  def handle_topic_close(_topic, _reason, socket) do
-    Logger.warning("Agent channel closed, will rejoin on reconnect...")
-    reconnect_or_keep(socket)
+  def handle_topic_close(topic, _reason, socket) do
+    Logger.warning("Agent channel closed, rejoining...")
+    rejoin(socket, topic)
   end
 
   @impl true
@@ -92,8 +92,12 @@ defmodule CitadelAgent.Socket do
 
   defp reconnect_or_keep(socket) do
     case reconnect(socket) do
-      {:ok, socket} -> {:ok, socket}
-      {:error, _reason} -> {:ok, socket}
+      {:ok, socket} ->
+        {:ok, socket}
+
+      {:error, reason} ->
+        Logger.error("Failed to reconnect WebSocket: #{inspect(reason)}")
+        {:ok, socket}
     end
   end
 


### PR DESCRIPTION
## Fix agent presence loss after channel close

### Problem

Agents can silently lose presence (stop appearing as connected) even while running and polling for work. Two bugs in `CitadelAgent.Socket` cause this:

**Gap 1: `handle_topic_close` calls `reconnect` instead of `rejoin`**

When a channel topic closes but the WebSocket remains connected (e.g. server-side channel crash or redeploy), `handle_topic_close/3` calls `reconnect_or_keep/1` → `Slipstream.reconnect/1`. However, `reconnect/1` returns `{:error, :connected}` when the socket is already connected and does nothing. Slipstream's own default `handle_topic_close` correctly calls `rejoin(socket, topic)` instead.

**Result:** The agent holds a live WebSocket but never re-joins the channel. Presence is permanently lost until the agent restarts.

**Gap 2: `reconnect_or_keep` silently swallows errors**

`reconnect_or_keep/1` matches `{:error, _reason}` and returns `{:ok, socket}` with no logging and no retry, masking failures entirely.

### Solution

- In `handle_topic_close/3`, call `rejoin(socket, topic)` instead of `reconnect_or_keep(socket)` — the correct Slipstream pattern for re-joining a closed topic on a live connection
- Add error logging to `reconnect_or_keep/1` so reconnection failures are visible

### Impact

This is the likely primary cause of agents appearing offline despite running successfully. On server redeploys, the channel closes and `handle_topic_close` fires, but the rejoin never happens, leaving the agent invisible in presence tracking indefinitely.

### Files Changed

- `citadel_agent/lib/citadel_agent/socket.ex`