### PR TITLE
P-155

### DIFF
--- a/citadel_agent/lib/citadel_agent/socket.ex
+++ b/citadel_agent/lib/citadel_agent/socket.ex
@@ -26,7 +26,7 @@ defmodule CitadelAgent.Socket do
 
   @impl true
   def init(_opts) do
-    agent_name = CitadelAgent.config(:agent_name) || "citadel-agent"
+    agent_name = CitadelAgent.config(:agent_name) || default_agent_name()
     workspace_id = CitadelAgent.config(:workspace_id)
 
     socket =
@@ -95,6 +95,11 @@ defmodule CitadelAgent.Socket do
       {:ok, socket} -> {:ok, socket}
       {:error, _reason} -> {:ok, socket}
     end
+  end
+
+  defp default_agent_name do
+    suffix = :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
+    "citadel-agent-#{suffix}"
   end
 
   defp ws_uri do


### PR DESCRIPTION
## Problem

When multiple agents run without an explicit name configured, they all default to `"citadel-agent"`. Phoenix Presence uses the agent name as the tracking key, so the second agent overwrites the first — only one appears online at a time.

## Solution

Generate a unique default name when no explicit name is configured (`"citadel-agent-<short-random-suffix>"`), ensuring multiple unnamed agents are distinguishable in presence without requiring manual configuration.

## Changes

- `citadel_agent/lib/citadel_agent/socket.ex` — update the fallback default name to include a random suffix when no name is explicitly configured