### PR TITLE
P-156

### DIFF
--- a/citadel_agent/config/runtime.exs
+++ b/citadel_agent/config/runtime.exs
@@ -20,6 +20,10 @@ if stall_timeout = System.get_env("CITADEL_STALL_TIMEOUT") do
   config :citadel_agent, stall_timeout_ms: String.to_integer(stall_timeout)
 end
 
+if agent_name = System.get_env("CITADEL_AGENT_NAME") do
+  config :citadel_agent, agent_name: agent_name
+end
+
 if github_token = System.get_env("GITHUB_TOKEN") do
   config :citadel_agent, github_token: github_token
 end


### PR DESCRIPTION
## Add `CITADEL_AGENT_NAME` env var support in agent runtime config

Reads the `CITADEL_AGENT_NAME` environment variable in `citadel_agent/config/runtime.exs` and maps it to the `:agent_name` config key, fixing a bug where `CitadelAgent.config(:agent_name)` always returned `nil`.

### Changes

- `citadel_agent/config/runtime.exs` — add `CITADEL_AGENT_NAME` → `:agent_name` config entry alongside the other existing env var mappings

### Test plan

- [ ] Set `CITADEL_AGENT_NAME=my-agent` and verify `CitadelAgent.config(:agent_name)` returns `"my-agent"`
- [ ] Verify that leaving `CITADEL_AGENT_NAME` unset still results in `nil` (no regression)
- [ ] Confirm socket connection uses the configured name correctly