### PR TITLE
P-168: Fix agent status showing idle after server redeploy

### DIFF
--- a/citadel_agent/lib/citadel_agent/socket.ex
+++ b/citadel_agent/lib/citadel_agent/socket.ex
@@ -33,6 +33,8 @@ defmodule CitadelAgent.Socket do
       new_socket()
       |> assign(:workspace_id, workspace_id)
       |> assign(:agent_name, agent_name)
+      |> assign(:status, "idle")
+      |> assign(:current_task_id, nil)
       |> connect!(uri: ws_uri())
 
     {:ok, socket}
@@ -42,7 +44,12 @@ defmodule CitadelAgent.Socket do
   def handle_connect(socket) do
     Logger.info("Connected to Citadel WebSocket, joining agent channel")
 
-    {:ok, join(socket, "agents:lobby", %{"agent_name" => socket.assigns.agent_name})}
+    {:ok,
+     join(socket, "agents:lobby", %{
+       "agent_name" => socket.assigns.agent_name,
+       "status" => socket.assigns.status,
+       "current_task_id" => socket.assigns.current_task_id
+     })}
   end
 
   @impl true
@@ -70,6 +77,11 @@ defmodule CitadelAgent.Socket do
       "status" => status,
       "current_task_id" => current_task_id
     }
+
+    socket =
+      socket
+      |> assign(:status, status)
+      |> assign(:current_task_id, current_task_id)
 
     push(socket, "agents:lobby", "update_status", payload)
     {:noreply, socket}

--- a/lib/citadel_web/channels/agent_channel.ex
+++ b/lib/citadel_web/channels/agent_channel.ex
@@ -8,8 +8,13 @@ defmodule CitadelWeb.AgentChannel do
   alias CitadelWeb.AgentPresence
 
   @impl true
-  def join("agents:" <> _, %{"agent_name" => agent_name}, socket) do
-    socket = assign(socket, :agent_name, agent_name)
+  def join("agents:" <> _, %{"agent_name" => agent_name} = payload, socket) do
+    socket =
+      socket
+      |> assign(:agent_name, agent_name)
+      |> assign(:status, payload["status"] || "idle")
+      |> assign(:current_task_id, payload["current_task_id"])
+
     send(self(), :after_join)
     {:ok, %{workspace_id: socket.assigns.workspace_id}, socket}
   end
@@ -21,8 +26,8 @@ defmodule CitadelWeb.AgentChannel do
     topic = presence_topic(socket)
 
     AgentPresence.track(self(), topic, socket.assigns.agent_name, %{
-      status: "idle",
-      current_task_id: nil,
+      status: socket.assigns.status,
+      current_task_id: socket.assigns.current_task_id,
       agent_name: socket.assigns.agent_name,
       joined_at: DateTime.utc_now() |> DateTime.to_iso8601()
     })

--- a/test/citadel_web/channels/agent_channel_test.exs
+++ b/test/citadel_web/channels/agent_channel_test.exs
@@ -14,7 +14,41 @@ defmodule CitadelWeb.AgentChannelTest do
         "agent_name" => agent_name
       })
 
-    %{socket: socket, workspace_id: workspace_id}
+    %{socket: socket, workspace_id: workspace_id, agent_name: agent_name}
+  end
+
+  describe "join" do
+    test "defaults to idle status when no status provided", %{agent_name: agent_name} do
+      workspace_id = Ash.UUID.generate()
+
+      {:ok, _reply, socket} =
+        CitadelWeb.AgentSocket
+        |> socket("agent_socket:#{workspace_id}", %{workspace_id: workspace_id})
+        |> subscribe_and_join(AgentChannel, "agents:#{workspace_id}", %{
+          "agent_name" => agent_name
+        })
+
+      assert socket.assigns.status == "idle"
+      assert socket.assigns.current_task_id == nil
+    end
+
+    test "uses status from join payload when provided" do
+      workspace_id = Ash.UUID.generate()
+      agent_name = "test-agent-#{System.unique_integer([:positive])}"
+      task_id = Ash.UUID.generate()
+
+      {:ok, _reply, socket} =
+        CitadelWeb.AgentSocket
+        |> socket("agent_socket:#{workspace_id}", %{workspace_id: workspace_id})
+        |> subscribe_and_join(AgentChannel, "agents:#{workspace_id}", %{
+          "agent_name" => agent_name,
+          "status" => "working",
+          "current_task_id" => task_id
+        })
+
+      assert socket.assigns.status == "working"
+      assert socket.assigns.current_task_id == task_id
+    end
   end
 
   describe "stream_output" do


### PR DESCRIPTION
## Fix agent presence showing idle after server redeploy

Agent runners were always shown as `"idle"` after a server redeploy, even when actively working on a task.

### Root Cause

`AgentChannel` hardcoded `status: "idle"` in `AgentPresence.track()` on every join, and `CitadelAgent.Socket` didn't track its own status in state — so there was nothing to report on reconnect.

### Changes

- Track `status` and `current_task_id` in `CitadelAgent.Socket` assigns
- Include current status in the channel join payload
- Have `AgentChannel` use the reported status instead of hardcoding `"idle"`
- Default to `"idle"` when status is not provided (backwards compatibility with older agents)

### Behavior After Fix

- Agents actively working on a task show `"working"` with the correct `current_task_id` after reconnect
- Idle agents continue to show `"idle"` after reconnect
- No breaking changes for agents that don't send status in the join payload