### PR TITLE
chore: add .mcp.json with citadel-dev MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,30 @@
+{
+  "mcpServers": {
+    "tidewave": {
+      "type": "http",
+      "url": "http://localhost:4100/tidewave/mcp"
+    },
+    "citadel-dev": {
+      "type": "http",
+      "url": "http://localhost:4002/mcp",
+      "headers": {
+        "Authorization": "Bearer ${CITADEL_DEV_API_KEY}"
+      }
+    },
+    "pyllar": {
+      "type": "http",
+      "url": "https://citadel-floral-star-4898.fly.dev/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PYLLAR_API_KEY}"
+      }
+    },
+    "daisyui": {
+      "type": "sse",
+      "url": "https://gitmcp.io/saadeghi/daisyui"
+    },
+    "stripe": {
+      "type": "http",
+      "url": "https://mcp.stripe.com/"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Tracks `.mcp.json` in git (was previously in `.git/info/exclude`)
- Adds `citadel-dev` MCP server pointing to `http://localhost:4002/mcp` so agents running in worktrees have access to `ask_question` and other Citadel tools during local development
- Credentials use env var substitution (`CITADEL_DEV_API_KEY`, `PYLLAR_API_KEY`) — no hardcoded secrets

## Setup
Set these env vars locally:
- `CITADEL_DEV_API_KEY` — API key for the local Citadel dev server
- `PYLLAR_API_KEY` — existing Pyllar production API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)