### PR TITLE
fix(mcp): add OAuth protected resource discovery endpoint

### DIFF
--- a/lib/citadel_web/controllers/mcp_oauth_discovery_controller.ex
+++ b/lib/citadel_web/controllers/mcp_oauth_discovery_controller.ex
@@ -1,0 +1,18 @@
+defmodule CitadelWeb.McpOAuthDiscoveryController do
+  use CitadelWeb, :controller
+
+  def show(conn, _params) do
+    base_url = CitadelWeb.Endpoint.url()
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(
+      200,
+      Jason.encode!(%{
+        resource: "#{base_url}/mcp",
+        bearer_methods_supported: ["header"],
+        resource_signing_alg_values_supported: []
+      })
+    )
+  end
+end

--- a/lib/citadel_web/router.ex
+++ b/lib/citadel_web/router.ex
@@ -97,6 +97,11 @@ defmodule CitadelWeb.Router do
     end
   end
 
+  scope "/.well-known" do
+    get "/oauth-protected-resource/mcp", CitadelWeb.McpOAuthDiscoveryController, :show
+    get "/oauth-protected-resource", CitadelWeb.McpOAuthDiscoveryController, :show
+  end
+
   scope "/mcp" do
     pipe_through :mcp
 


### PR DESCRIPTION
## Summary
- Adds `/.well-known/oauth-protected-resource` endpoint so MCP clients know to use bearer token auth directly
- Fixes MCP authentication failures caused by clients attempting OAuth discovery before falling back to static bearer tokens

## Test plan
- [x] Verified endpoint returns correct JSON response on local server
- [ ] Deploy and confirm MCP tools authenticate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)