### PR TITLE
fix(mcp): return 404 for OAuth discovery under /mcp

### DIFF
--- a/lib/citadel_web/controllers/mcp_oauth_discovery_controller.ex
+++ b/lib/citadel_web/controllers/mcp_oauth_discovery_controller.ex
@@ -1,18 +1,9 @@
 defmodule CitadelWeb.McpOAuthDiscoveryController do
   use CitadelWeb, :controller
 
-  def show(conn, _params) do
-    base_url = CitadelWeb.Endpoint.url()
-
+  def not_found(conn, _params) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(
-      200,
-      Jason.encode!(%{
-        resource: "#{base_url}/mcp",
-        bearer_methods_supported: ["header"],
-        resource_signing_alg_values_supported: []
-      })
-    )
+    |> send_resp(404, Jason.encode!(%{error: "not_found"}))
   end
 end

--- a/lib/citadel_web/router.ex
+++ b/lib/citadel_web/router.ex
@@ -97,9 +97,8 @@ defmodule CitadelWeb.Router do
     end
   end
 
-  scope "/.well-known" do
-    get "/oauth-protected-resource/mcp", CitadelWeb.McpOAuthDiscoveryController, :show
-    get "/oauth-protected-resource", CitadelWeb.McpOAuthDiscoveryController, :show
+  scope "/mcp/.well-known" do
+    get "/*path", CitadelWeb.McpOAuthDiscoveryController, :not_found
   end
 
   scope "/mcp" do


### PR DESCRIPTION
## Summary
- Catches `/mcp/.well-known/*` requests before the `:mcp` auth pipeline so they return 404 instead of 401
- Prevents Claude Code's MCP client from interpreting 401 as "OAuth required" and entering a broken OAuth flow
- Replaces the previous protected resource discovery endpoint which was making the issue worse

## Test plan
- [x] Verified `/mcp/.well-known/openid-configuration` returns 404 locally
- [x] Verified MCP endpoint still works with bearer token auth via curl
- [ ] Deploy and confirm Claude Code MCP tools authenticate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)