### PR TITLE
fix: use uuid_generate_v7() for backfilled activity records

### DIFF
--- a/priv/repo/migrations/20260330145205_backfill_agent_run_activities.exs
+++ b/priv/repo/migrations/20260330145205_backfill_agent_run_activities.exs
@@ -11,7 +11,7 @@ defmodule Citadel.Repo.Migrations.BackfillAgentRunActivities do
   def up do
     execute("""
     INSERT INTO task_activities (id, type, actor_type, actor_display_name, task_id, workspace_id, agent_run_id, inserted_at, updated_at)
-    SELECT gen_random_uuid(), 'agent_run', 'ai', 'Agent', task_id, workspace_id, id, inserted_at, inserted_at
+    SELECT uuid_generate_v7(), 'agent_run', 'ai', 'Agent', task_id, workspace_id, id, inserted_at, inserted_at
     FROM agent_runs
     WHERE NOT EXISTS (
       SELECT 1 FROM task_activities WHERE task_activities.agent_run_id = agent_runs.id

--- a/priv/repo/migrations/20260407000000_fix_backfilled_activity_uuids.exs
+++ b/priv/repo/migrations/20260407000000_fix_backfilled_activity_uuids.exs
@@ -1,0 +1,22 @@
+defmodule Citadel.Repo.Migrations.FixBackfilledActivityUuids do
+  @moduledoc """
+  Regenerates UUIDs for backfilled agent_run activities that were
+  incorrectly created with gen_random_uuid() (v4) instead of
+  uuid_generate_v7(). The v4 UUIDs fail to load as Ash.Type.UUIDv7.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE task_activities
+    SET id = uuid_generate_v7()
+    WHERE type = 'agent_run'
+      AND agent_run_id IS NOT NULL
+    """)
+  end
+
+  def down do
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary
- The backfill migration (`20260330145205`) used `gen_random_uuid()` which generates v4 UUIDs, but `TaskActivity` expects UUIDv7 via `uuid_v7_primary_key`. This causes an `ArgumentError` when loading task activities in prod.
- Fixes the original migration to use `uuid_generate_v7()` for fresh environments
- Adds a corrective migration to regenerate IDs for already-backfilled rows in prod

## Test plan
- [x] All 282 task tests pass
- [ ] Deploy and verify the task show page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)