### PR TITLE
debug: add logging to MaybeEnqueueAgentWork

### DIFF
--- a/lib/citadel/tasks/changes/maybe_enqueue_agent_work.ex
+++ b/lib/citadel/tasks/changes/maybe_enqueue_agent_work.ex
@@ -20,11 +20,25 @@ defmodule Citadel.Tasks.Changes.MaybeEnqueueAgentWork do
   end
 
   defp should_enqueue?(task) do
-    task.agent_eligible == true &&
-      workable_state?(task.task_state_id) &&
-      !blocked?(task) &&
-      !active_run_exists?(task.id, task.workspace_id) &&
-      !active_work_item_exists?(task.id, task.workspace_id)
+    require Logger
+
+    eligible = task.agent_eligible == true
+    workable = workable_state?(task.task_state_id)
+    blocked = blocked?(task)
+    active_run = active_run_exists?(task.id, task.workspace_id)
+    active_work_item = active_work_item_exists?(task.id, task.workspace_id)
+
+    result = eligible && workable && !blocked && !active_run && !active_work_item
+
+    unless result do
+      Logger.warning(
+        "MaybeEnqueueAgentWork: skipping task #{task.id} — " <>
+          "eligible=#{eligible}, workable=#{workable}, blocked=#{blocked}, " <>
+          "active_run=#{active_run}, active_work_item=#{active_work_item}"
+      )
+    end
+
+    result
   end
 
   defp blocked?(task) do


### PR DESCRIPTION
## Summary
- Adds debug logging to `should_enqueue?/1` in `MaybeEnqueueAgentWork` to identify which condition is preventing work item creation for agent-eligible tasks
- Logs: `eligible`, `workable`, `blocked`, `active_run`, `active_work_item` when a task is skipped

## Test plan
- [ ] Deploy and toggle `agent_eligible` on the stuck task in production
- [ ] Check logs for `MaybeEnqueueAgentWork: skipping task` message
- [ ] Remove logging after root cause is identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)