### PR TITLE
P-174: Add Svelte build pipeline to assets

### DIFF
--- a/assets/build_svelte.js
+++ b/assets/build_svelte.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const esbuild = require("esbuild");
 const sveltePlugin = require("esbuild-svelte");
 
@@ -5,6 +6,7 @@ const isWatch = process.argv.includes("--watch");
 const isMinify = process.argv.includes("--minify");
 
 const buildOptions = {
+  absWorkingDir: path.resolve(__dirname),
   entryPoints: ["svelte/index.js"],
   bundle: true,
   outdir: "../priv/static/assets/js/svelte",
@@ -15,7 +17,10 @@ const buildOptions = {
   sourcemap: isWatch ? "inline" : false,
   plugins: [
     sveltePlugin({
-      compilerOptions: { css: "injected" },
+      compilerOptions: {
+        css: "injected",
+        compatibility: { componentApi: 4 },
+      },
     }),
   ],
   logLevel: "info",

--- a/assets/build_svelte.js
+++ b/assets/build_svelte.js
@@ -1,0 +1,41 @@
+const esbuild = require("esbuild");
+const sveltePlugin = require("esbuild-svelte");
+
+const isWatch = process.argv.includes("--watch");
+const isMinify = process.argv.includes("--minify");
+
+const buildOptions = {
+  entryPoints: ["svelte/index.js"],
+  bundle: true,
+  outdir: "../priv/static/assets/js/svelte",
+  format: "esm",
+  splitting: true,
+  target: "es2022",
+  minify: isMinify,
+  sourcemap: isWatch ? "inline" : false,
+  plugins: [
+    sveltePlugin({
+      compilerOptions: { css: "injected" },
+    }),
+  ],
+  logLevel: "info",
+};
+
+async function run() {
+  if (isWatch) {
+    const ctx = await esbuild.context(buildOptions);
+    await ctx.watch();
+    process.stdin.on("end", () => {
+      ctx.dispose();
+      process.exit(0);
+    });
+    process.stdin.resume();
+  } else {
+    await esbuild.build(buildOptions);
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,12 +29,13 @@ import Clipboard from "./hooks/clipboard.js"
 import MilkdownEditor from "./hooks/milkdown_editor.js"
 import CmdEnterSubmit from "./hooks/cmd_enter_submit.js"
 import AutoScroll from "./hooks/auto_scroll.js"
+import WorkflowEditor from "./hooks/workflow_editor.js"
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, TaskDragDrop, Clipboard, MilkdownEditor, CmdEnterSubmit, AutoScroll},
+  hooks: {...colocatedHooks, TaskDragDrop, Clipboard, MilkdownEditor, CmdEnterSubmit, AutoScroll, WorkflowEditor},
 })
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/hooks/workflow_editor.js
+++ b/assets/js/hooks/workflow_editor.js
@@ -1,0 +1,139 @@
+const WORKFLOW_NODES = [
+  {
+    id: "start",
+    type: "workflow",
+    data: { label: "Start", nodeType: "start", description: "Workflow begins" },
+  },
+  {
+    id: "plan",
+    type: "workflow",
+    data: {
+      label: "Plan",
+      nodeType: "action",
+      description: "Define approach and goals",
+    },
+  },
+  {
+    id: "research",
+    type: "workflow",
+    data: {
+      label: "Research",
+      nodeType: "action",
+      description: "Gather context and information",
+    },
+  },
+  {
+    id: "execute",
+    type: "workflow",
+    data: {
+      label: "Execute",
+      nodeType: "action",
+      description: "Implement the solution",
+    },
+  },
+  {
+    id: "quality",
+    type: "workflow",
+    data: {
+      label: "Quality Check",
+      nodeType: "action",
+      description: "Verify output quality",
+    },
+  },
+  {
+    id: "review",
+    type: "workflow",
+    data: {
+      label: "Review",
+      nodeType: "decision",
+      description: "Evaluate results",
+    },
+  },
+  {
+    id: "complete",
+    type: "workflow",
+    data: {
+      label: "Complete",
+      nodeType: "end",
+      description: "Workflow finished",
+    },
+  },
+];
+
+const WORKFLOW_EDGES = [
+  { id: "start-plan", source: "start", target: "plan", type: "smoothstep" },
+  {
+    id: "plan-research",
+    source: "plan",
+    target: "research",
+    type: "smoothstep",
+  },
+  {
+    id: "research-execute",
+    source: "research",
+    target: "execute",
+    type: "smoothstep",
+  },
+  {
+    id: "execute-quality",
+    source: "execute",
+    target: "quality",
+    type: "smoothstep",
+  },
+  {
+    id: "quality-review",
+    source: "quality",
+    target: "review",
+    type: "smoothstep",
+  },
+  {
+    id: "review-complete",
+    source: "review",
+    target: "complete",
+    type: "smoothstep",
+    label: "Approved",
+  },
+  {
+    id: "review-execute",
+    source: "review",
+    target: "execute",
+    type: "smoothstep",
+    label: "Needs changes",
+    animated: true,
+  },
+];
+
+function loadCSS() {
+  if (!document.querySelector("[data-workflow-css]")) {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "/assets/js/svelte/index.css";
+    link.setAttribute("data-workflow-css", "");
+    document.head.appendChild(link);
+  }
+}
+
+const WorkflowEditor = {
+  async mounted() {
+    loadCSS();
+
+    const svelteBundle = "/assets/js/svelte/index.js";
+    const { WorkflowGraph } = await import(svelteBundle);
+
+    this._component = new WorkflowGraph({
+      target: this.el,
+      props: {
+        initialNodes: WORKFLOW_NODES,
+        initialEdges: WORKFLOW_EDGES,
+      },
+    });
+  },
+
+  destroyed() {
+    if (this._component) {
+      this._component.$destroy();
+    }
+  },
+};
+
+export default WorkflowEditor;

--- a/assets/js/hooks/workflow_editor.js
+++ b/assets/js/hooks/workflow_editor.js
@@ -29,6 +29,7 @@ const WORKFLOW_NODES = [
       label: "Execute",
       nodeType: "action",
       description: "Implement the solution",
+      status: "running",
     },
   },
   {

--- a/assets/js/hooks/workflow_editor.js
+++ b/assets/js/hooks/workflow_editor.js
@@ -97,10 +97,11 @@ const WORKFLOW_EDGES = [
   {
     id: "review-execute",
     source: "review",
+    sourceHandle: "bottom-source",
     target: "execute",
+    targetHandle: "bottom-target",
     type: "smoothstep",
     label: "Needs changes",
-    animated: true,
   },
 ];
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,13 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@milkdown/kit": "^7.6.0",
         "@milkdown/plugin-highlight": "^7.6.0",
+        "@xyflow/svelte": "^1.5.2",
+        "@xyflow/system": "^0.0.76",
+        "esbuild": "^0.28.0",
+        "esbuild-svelte": "^0.9.4",
         "highlight.js": "^11.9.0",
-        "lowlight": "^3.0.0"
-      },
-      "devDependencies": {
-        "@playwright/test": "^1.58.2"
+        "lowlight": "^3.0.0",
+        "svelte": "^5.55.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -91,6 +94,409 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA=="
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
@@ -113,10 +519,45 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@lezer/common": {
       "version": "1.4.0",
@@ -442,19 +883,63 @@
         "url": "https://github.com/sponsors/ocavue"
       }
     },
-    "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "dev": true,
+    "node_modules/@svelte-put/shortcut": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@svelte-put/shortcut/-/shortcut-4.1.0.tgz",
+      "integrity": "sha512-wImNEIkbxAIWFqlfuhcbC+jRPDeRa/uJGIXHMEVVD+jqL9xCwWNnkGQJ6Qb2XVszuRLHlb8SGZDL3Io/h3vs8w==",
+      "peerDependencies": {
+        "svelte": "^5.1.0"
+      }
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
       "dependencies": {
-        "playwright": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -464,6 +949,11 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -502,13 +992,24 @@
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "optional": true
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.25",
@@ -601,6 +1102,61 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.25.tgz",
       "integrity": "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg=="
     },
+    "node_modules/@xyflow/svelte": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/svelte/-/svelte-1.5.2.tgz",
+      "integrity": "sha512-jPLc2cwRmrkXSv/jvsNDQqTGCsNyTWURKtBl28UCH3BdOAA3CIc0/oQ0EvIcjPdzr0NwvWMgq9TmLdjOIccCEQ==",
+      "dependencies": {
+        "@svelte-put/shortcut": "^4.1.0",
+        "@xyflow/system": "0.0.76"
+      },
+      "peerDependencies": {
+        "svelte": "^5.25.0"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -647,6 +1203,102 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -683,6 +1335,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/devalue": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -714,6 +1371,61 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/esbuild-svelte": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/esbuild-svelte/-/esbuild-svelte-0.9.4.tgz",
+      "integrity": "sha512-v/a0GjkKN06nal2QLluxjk2GXsei3fdtjIuHRa6pVnri5rQBZ6pj4a2WwjLfRojgRsLwDHl4xSeZ1BeUHsqQrw==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.19"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.17.0",
+        "svelte": ">=4.2.1 <6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -725,6 +1437,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="
+    },
+    "node_modules/esrap": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
+      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@typescript-eslint/types": "^8.2.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -734,20 +1460,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/highlight.js": {
       "version": "11.11.1",
@@ -767,6 +1479,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -1572,36 +2297,6 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
-    "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -1944,6 +2639,32 @@
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "peer": true
     },
+    "node_modules/svelte": {
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.2.tgz",
+      "integrity": "sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.6.4",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.4",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -2072,6 +2793,11 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,9 +1,15 @@
 {
   "private": true,
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@milkdown/kit": "^7.6.0",
     "@milkdown/plugin-highlight": "^7.6.0",
+    "@xyflow/svelte": "^1.5.2",
+    "@xyflow/system": "^0.0.76",
+    "esbuild": "^0.28.0",
+    "esbuild-svelte": "^0.9.4",
     "highlight.js": "^11.9.0",
-    "lowlight": "^3.0.0"
+    "lowlight": "^3.0.0",
+    "svelte": "^5.55.2"
   }
 }

--- a/assets/svelte/App.svelte
+++ b/assets/svelte/App.svelte
@@ -1,0 +1,7 @@
+<script>
+  let { name = "Svelte" } = $props();
+</script>
+
+<div class="svelte-app">
+  <p>Hello from {name}!</p>
+</div>

--- a/assets/svelte/DetailPanel.svelte
+++ b/assets/svelte/DetailPanel.svelte
@@ -9,10 +9,10 @@
   };
 
   const typeColors = {
-    start: 'oklch(77% 0.152 181.912)',
-    end: 'oklch(83.92% 0.0901 136.87)',
-    action: 'oklch(80% 0 0)',
-    decision: 'oklch(80.39% 0.1148 241.68)',
+    start: 'oklch(70% 0 0)',
+    end: 'oklch(70% 0 0)',
+    action: 'oklch(70% 0 0)',
+    decision: 'oklch(70% 0 0)',
   };
 
   function handleBackdropClick(e) {

--- a/assets/svelte/DetailPanel.svelte
+++ b/assets/svelte/DetailPanel.svelte
@@ -1,0 +1,205 @@
+<script>
+  let { node = null, onclose } = $props();
+
+  const typeLabels = {
+    start: 'Start',
+    end: 'End',
+    action: 'Action',
+    decision: 'Decision',
+  };
+
+  const typeColors = {
+    start: 'oklch(77% 0.152 181.912)',
+    end: 'oklch(83.92% 0.0901 136.87)',
+    action: 'oklch(80% 0 0)',
+    decision: 'oklch(80.39% 0.1148 241.68)',
+  };
+
+  function handleBackdropClick(e) {
+    if (e.target === e.currentTarget) {
+      onclose();
+    }
+  }
+</script>
+
+{#if node}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="panel-backdrop" onclick={handleBackdropClick}>
+    <div class="detail-panel">
+      <div class="panel-header">
+        <span class="panel-title">Node Details</span>
+        <button class="close-btn" onclick={onclose}>✕</button>
+      </div>
+
+      <div class="panel-body">
+        <div class="field">
+          <span class="field-label">Label</span>
+          <span class="field-value">{node.data.label}</span>
+        </div>
+
+        <div class="field">
+          <span class="field-label">Type</span>
+          <span
+            class="type-tag"
+            style="color: {typeColors[node.data.nodeType]}; border-color: {typeColors[node.data.nodeType]}"
+          >
+            {typeLabels[node.data.nodeType] || node.data.nodeType}
+          </span>
+        </div>
+
+        {#if node.data.description}
+          <div class="field">
+            <span class="field-label">Description</span>
+            <span class="field-value desc">{node.data.description}</span>
+          </div>
+        {/if}
+
+        {#if node.data.status}
+          <div class="field">
+            <span class="field-label">Status</span>
+            <span class="status-indicator" class:running={node.data.status === 'running'}>
+              {#if node.data.status === 'running'}
+                <span class="pulse-dot"></span>
+              {/if}
+              {node.data.status}
+            </span>
+          </div>
+        {/if}
+
+        <div class="field">
+          <span class="field-label">ID</span>
+          <span class="field-value mono">{node.id}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .panel-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+  }
+
+  .detail-panel {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 280px;
+    background: oklch(12% 0 150);
+    border: 1px solid oklch(25% 0 0);
+    border-radius: 6px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    font-family: system-ui, -apple-system, sans-serif;
+    color: oklch(93% 0.005 50);
+    overflow: hidden;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    border-bottom: 1px solid oklch(20% 0 150);
+    background: oklch(10% 0 150);
+  }
+
+  .panel-title {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.6;
+  }
+
+  .close-btn {
+    background: none;
+    border: none;
+    color: oklch(60% 0 0);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    line-height: 1;
+    transition: color 0.15s ease, background 0.15s ease;
+  }
+
+  .close-btn:hover {
+    color: oklch(93% 0.005 50);
+    background: oklch(20% 0 150);
+  }
+
+  .panel-body {
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .field-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.45;
+  }
+
+  .field-value {
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  .field-value.desc {
+    opacity: 0.75;
+  }
+
+  .field-value.mono {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    opacity: 0.5;
+  }
+
+  .type-tag {
+    display: inline-flex;
+    align-self: flex-start;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 8px;
+    border: 1px solid;
+    border-radius: 4px;
+    background: oklch(15% 0 150);
+  }
+
+  .status-indicator {
+    font-size: 12px;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    text-transform: capitalize;
+  }
+
+  .status-indicator.running {
+    color: oklch(77% 0.152 181.912);
+  }
+
+  @keyframes dot-pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+  }
+
+  .pulse-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: oklch(77% 0.152 181.912);
+    animation: dot-pulse 1.5s ease-in-out infinite;
+  }
+</style>

--- a/assets/svelte/WorkflowGraph.svelte
+++ b/assets/svelte/WorkflowGraph.svelte
@@ -15,13 +15,15 @@
   function getLayoutedElements(rawNodes, rawEdges) {
     const g = new dagre.graphlib.Graph();
     g.setDefaultEdgeLabel(() => ({}));
-    g.setGraph({ rankdir: 'TB', nodesep: 60, ranksep: 100 });
+    g.setGraph({ rankdir: 'LR', nodesep: 60, ranksep: 100 });
+
+    const forwardEdges = rawEdges.filter((e) => !e.sourceHandle);
 
     for (const node of rawNodes) {
       g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
     }
 
-    for (const edge of rawEdges) {
+    for (const edge of forwardEdges) {
       g.setEdge(edge.source, edge.target);
     }
 
@@ -41,24 +43,11 @@
     return { nodes: layoutedNodes, edges: rawEdges };
   }
 
-  function styleEdges(edges, nodes) {
-    const runningNodeIds = new Set(
-      nodes.filter((n) => n.data.status === 'running').map((n) => n.id)
-    );
-
-    return edges.map((edge) => {
-      if (runningNodeIds.has(edge.target)) {
-        return {
-          ...edge,
-          animated: true,
-          style: 'stroke: oklch(77% 0.152 181.912); stroke-width: 2px;',
-        };
-      }
-      return {
-        ...edge,
-        style: 'stroke: oklch(30% 0 0); stroke-width: 1.5px;',
-      };
-    });
+  function styleEdges(edges) {
+    return edges.map((edge) => ({
+      ...edge,
+      style: 'stroke: oklch(30% 0 0); stroke-width: 1px;',
+    }));
   }
 
   function handleNodeClick(_event, node) {
@@ -75,7 +64,7 @@
 
   const nodeTypes = { workflow: WorkflowNode };
   const layout = getLayoutedElements(initialNodes, initialEdges);
-  const styledEdges = styleEdges(layout.edges, initialNodes);
+  const styledEdges = styleEdges(layout.edges);
 </script>
 
 <div class="workflow-graph-container">
@@ -112,8 +101,8 @@
   }
 
   :global(.svelte-flow__edge-text) {
-    fill: oklch(60% 0 0) !important;
-    font-size: 11px !important;
+    fill: oklch(50% 0 0) !important;
+    font-size: 10px !important;
   }
 
   :global(.svelte-flow__edge-textbg) {
@@ -130,8 +119,8 @@
   :global(.svelte-flow__controls button) {
     background: oklch(15% 0 150) !important;
     border-color: oklch(25% 0 0) !important;
-    color: oklch(70% 0 0) !important;
-    fill: oklch(70% 0 0) !important;
+    color: oklch(60% 0 0) !important;
+    fill: oklch(60% 0 0) !important;
   }
 
   :global(.svelte-flow__controls button:hover) {
@@ -139,10 +128,10 @@
   }
 
   :global(.svelte-flow__controls button svg) {
-    fill: oklch(70% 0 0) !important;
+    fill: oklch(60% 0 0) !important;
   }
 
   :global(.svelte-flow__background pattern circle) {
-    fill: oklch(18% 0 0) !important;
+    fill: oklch(16% 0 0) !important;
   }
 </style>

--- a/assets/svelte/WorkflowGraph.svelte
+++ b/assets/svelte/WorkflowGraph.svelte
@@ -2,12 +2,15 @@
   import { SvelteFlow, Controls, Background } from '@xyflow/svelte';
   import dagre from '@dagrejs/dagre';
   import WorkflowNode from './WorkflowNode.svelte';
+  import DetailPanel from './DetailPanel.svelte';
   import '@xyflow/svelte/dist/style.css';
 
   let { initialNodes = [], initialEdges = [] } = $props();
 
   const NODE_WIDTH = 200;
   const NODE_HEIGHT = 80;
+
+  let selectedNode = $state(null);
 
   function getLayoutedElements(rawNodes, rawEdges) {
     const g = new dagre.graphlib.Graph();
@@ -38,26 +41,108 @@
     return { nodes: layoutedNodes, edges: rawEdges };
   }
 
+  function styleEdges(edges, nodes) {
+    const runningNodeIds = new Set(
+      nodes.filter((n) => n.data.status === 'running').map((n) => n.id)
+    );
+
+    return edges.map((edge) => {
+      if (runningNodeIds.has(edge.target)) {
+        return {
+          ...edge,
+          animated: true,
+          style: 'stroke: oklch(77% 0.152 181.912); stroke-width: 2px;',
+        };
+      }
+      return {
+        ...edge,
+        style: 'stroke: oklch(30% 0 0); stroke-width: 1.5px;',
+      };
+    });
+  }
+
+  function handleNodeClick(_event, node) {
+    selectedNode = node;
+  }
+
+  function handlePaneClick() {
+    selectedNode = null;
+  }
+
+  function closePanel() {
+    selectedNode = null;
+  }
+
   const nodeTypes = { workflow: WorkflowNode };
   const layout = getLayoutedElements(initialNodes, initialEdges);
+  const styledEdges = styleEdges(layout.edges, initialNodes);
 </script>
 
 <div class="workflow-graph-container">
   <SvelteFlow
     nodes={layout.nodes}
-    edges={layout.edges}
+    edges={styledEdges}
     {nodeTypes}
     fitView
+    onnodeclick={handleNodeClick}
+    onpaneclick={handlePaneClick}
     proOptions={{ hideAttribution: true }}
+    colorMode="dark"
   >
     <Controls />
     <Background />
   </SvelteFlow>
+
+  <DetailPanel node={selectedNode} onclose={closePanel} />
 </div>
 
 <style>
   .workflow-graph-container {
     width: 100%;
     height: 100%;
+    position: relative;
+  }
+
+  :global(.svelte-flow) {
+    background: oklch(10% 0 150) !important;
+  }
+
+  :global(.svelte-flow__edge-path) {
+    stroke: oklch(30% 0 0);
+  }
+
+  :global(.svelte-flow__edge-text) {
+    fill: oklch(60% 0 0) !important;
+    font-size: 11px !important;
+  }
+
+  :global(.svelte-flow__edge-textbg) {
+    fill: oklch(10% 0 150) !important;
+  }
+
+  :global(.svelte-flow__controls) {
+    background: oklch(15% 0 150) !important;
+    border: 1px solid oklch(25% 0 0) !important;
+    border-radius: 6px !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3) !important;
+  }
+
+  :global(.svelte-flow__controls button) {
+    background: oklch(15% 0 150) !important;
+    border-color: oklch(25% 0 0) !important;
+    color: oklch(70% 0 0) !important;
+    fill: oklch(70% 0 0) !important;
+  }
+
+  :global(.svelte-flow__controls button:hover) {
+    background: oklch(20% 0 150) !important;
+  }
+
+  :global(.svelte-flow__controls button svg) {
+    fill: oklch(70% 0 0) !important;
+  }
+
+  :global(.svelte-flow__background pattern circle) {
+    fill: oklch(18% 0 0) !important;
   }
 </style>

--- a/assets/svelte/WorkflowGraph.svelte
+++ b/assets/svelte/WorkflowGraph.svelte
@@ -1,0 +1,63 @@
+<script>
+  import { SvelteFlow, Controls, Background } from '@xyflow/svelte';
+  import dagre from '@dagrejs/dagre';
+  import WorkflowNode from './WorkflowNode.svelte';
+  import '@xyflow/svelte/dist/style.css';
+
+  let { initialNodes = [], initialEdges = [] } = $props();
+
+  const NODE_WIDTH = 200;
+  const NODE_HEIGHT = 80;
+
+  function getLayoutedElements(rawNodes, rawEdges) {
+    const g = new dagre.graphlib.Graph();
+    g.setDefaultEdgeLabel(() => ({}));
+    g.setGraph({ rankdir: 'TB', nodesep: 60, ranksep: 100 });
+
+    for (const node of rawNodes) {
+      g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+    }
+
+    for (const edge of rawEdges) {
+      g.setEdge(edge.source, edge.target);
+    }
+
+    dagre.layout(g);
+
+    const layoutedNodes = rawNodes.map((node) => {
+      const pos = g.node(node.id);
+      return {
+        ...node,
+        position: {
+          x: pos.x - NODE_WIDTH / 2,
+          y: pos.y - NODE_HEIGHT / 2,
+        },
+      };
+    });
+
+    return { nodes: layoutedNodes, edges: rawEdges };
+  }
+
+  const nodeTypes = { workflow: WorkflowNode };
+  const layout = getLayoutedElements(initialNodes, initialEdges);
+</script>
+
+<div class="workflow-graph-container">
+  <SvelteFlow
+    nodes={layout.nodes}
+    edges={layout.edges}
+    {nodeTypes}
+    fitView
+    proOptions={{ hideAttribution: true }}
+  >
+    <Controls />
+    <Background />
+  </SvelteFlow>
+</div>
+
+<style>
+  .workflow-graph-container {
+    width: 100%;
+    height: 100%;
+  }
+</style>

--- a/assets/svelte/WorkflowNode.svelte
+++ b/assets/svelte/WorkflowNode.svelte
@@ -5,59 +5,151 @@
 
   const showTarget = data.nodeType !== 'start';
   const showSource = data.nodeType !== 'end';
+  const isRunning = data.status === 'running';
+
+  const typeIcons = {
+    start: '▶',
+    end: '■',
+    action: '⚡',
+    decision: '◆',
+  };
 </script>
 
 {#if showTarget}
-  <Handle type="target" position={Position.Top} />
+  <Handle type="target" position={Position.Top} class="handle" />
 {/if}
 
-<div class="workflow-node" data-type={data.nodeType}>
-  <div class="node-label">{data.label}</div>
+<div
+  class="workflow-node"
+  class:running={isRunning}
+  data-type={data.nodeType}
+>
+  <div class="node-header">
+    <span class="type-badge" data-type={data.nodeType}>
+      {typeIcons[data.nodeType] || '●'}
+    </span>
+    <span class="node-label">{data.label}</span>
+  </div>
   {#if data.description}
     <div class="node-desc">{data.description}</div>
   {/if}
 </div>
 
 {#if showSource}
-  <Handle type="source" position={Position.Bottom} />
+  <Handle type="source" position={Position.Bottom} class="handle" />
 {/if}
 
 <style>
+  @keyframes runner-pulse {
+    0%, 100% {
+      box-shadow:
+        0 0 4px rgba(148, 226, 213, 0.3),
+        0 0 12px rgba(148, 226, 213, 0.15);
+    }
+    50% {
+      box-shadow:
+        0 0 8px rgba(148, 226, 213, 0.5),
+        0 0 24px rgba(148, 226, 213, 0.25),
+        0 0 40px rgba(148, 226, 213, 0.1);
+    }
+  }
+
   .workflow-node {
     padding: 10px 16px;
-    border-radius: 8px;
-    min-width: 150px;
-    text-align: center;
+    border-radius: 6px;
+    min-width: 160px;
+    text-align: left;
     font-family: system-ui, -apple-system, sans-serif;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+    background: oklch(15% 0 150);
+    color: oklch(93% 0.005 50);
+    border: 1.5px solid oklch(25% 0 0);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .workflow-node:hover {
+    border-color: oklch(35% 0 0);
   }
 
   .workflow-node[data-type='start'] {
-    background: linear-gradient(135deg, #10b981, #059669);
-    color: white;
-    border: 2px solid #047857;
+    border-color: oklch(77% 0.152 181.912);
     border-radius: 9999px;
-    padding: 12px 24px;
+    text-align: center;
+    padding: 10px 24px;
+  }
+  .workflow-node[data-type='start']:hover {
+    border-color: oklch(85% 0.152 181.912);
   }
 
   .workflow-node[data-type='end'] {
-    background: linear-gradient(135deg, #10b981, #059669);
-    color: white;
-    border: 2px solid #047857;
+    border-color: oklch(83.92% 0.0901 136.87);
     border-radius: 9999px;
-    padding: 12px 24px;
+    text-align: center;
+    padding: 10px 24px;
+  }
+  .workflow-node[data-type='end']:hover {
+    border-color: oklch(90% 0.0901 136.87);
   }
 
   .workflow-node[data-type='action'] {
-    background: linear-gradient(135deg, #6366f1, #4f46e5);
-    color: white;
-    border: 2px solid #4338ca;
+    border-color: oklch(25% 0 0);
   }
 
   .workflow-node[data-type='decision'] {
-    background: linear-gradient(135deg, #f59e0b, #d97706);
-    color: white;
-    border: 2px solid #b45309;
+    border-color: oklch(80.39% 0.1148 241.68);
+  }
+  .workflow-node[data-type='decision']:hover {
+    border-color: oklch(88% 0.1148 241.68);
+  }
+
+  .workflow-node.running {
+    border-color: oklch(77% 0.152 181.912);
+    animation: runner-pulse 2.5s ease-in-out infinite;
+  }
+
+  .node-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  [data-type='start'] .node-header,
+  [data-type='end'] .node-header {
+    justify-content: center;
+  }
+
+  .type-badge {
+    font-size: 10px;
+    width: 20px;
+    height: 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    flex-shrink: 0;
+    background: oklch(20% 0 150);
+    color: oklch(80% 0 0);
+  }
+
+  .type-badge[data-type='start'] {
+    background: oklch(77% 0.152 181.912 / 0.15);
+    color: oklch(77% 0.152 181.912);
+  }
+
+  .type-badge[data-type='end'] {
+    background: oklch(83.92% 0.0901 136.87 / 0.15);
+    color: oklch(83.92% 0.0901 136.87);
+  }
+
+  .type-badge[data-type='action'] {
+    background: oklch(25% 0 0);
+    color: oklch(80% 0 0);
+  }
+
+  .type-badge[data-type='decision'] {
+    background: oklch(80.39% 0.1148 241.68 / 0.15);
+    color: oklch(80.39% 0.1148 241.68);
   }
 
   .node-label {
@@ -68,8 +160,22 @@
 
   .node-desc {
     font-size: 11px;
-    opacity: 0.85;
+    opacity: 0.55;
     margin-top: 4px;
     line-height: 1.3;
+    padding-left: 26px;
+  }
+
+  [data-type='start'] .node-desc,
+  [data-type='end'] .node-desc {
+    padding-left: 0;
+  }
+
+  :global(.handle) {
+    width: 8px !important;
+    height: 8px !important;
+    background: oklch(25% 0 0) !important;
+    border: 1.5px solid oklch(40% 0 0) !important;
+    border-radius: 50% !important;
   }
 </style>

--- a/assets/svelte/WorkflowNode.svelte
+++ b/assets/svelte/WorkflowNode.svelte
@@ -6,29 +6,41 @@
   const showTarget = data.nodeType !== 'start';
   const showSource = data.nodeType !== 'end';
   const isRunning = data.status === 'running';
-
-  const typeIcons = {
-    start: '▶',
-    end: '■',
-    action: '⚡',
-    decision: '◆',
-  };
+  const isComplete = data.status === 'complete';
+  const isError = data.status === 'error';
 </script>
 
 {#if showTarget}
-  <Handle type="target" position={Position.Top} class="handle" />
+  <Handle id="left" type="target" position={Position.Left} class="handle" />
+  <Handle id="bottom-target" type="target" position={Position.Bottom} class="handle handle-loop" />
 {/if}
 
 <div
   class="workflow-node"
-  class:running={isRunning}
   data-type={data.nodeType}
 >
   <div class="node-header">
-    <span class="type-badge" data-type={data.nodeType}>
-      {typeIcons[data.nodeType] || '●'}
-    </span>
+    {#if data.nodeType === 'start'}
+      <span class="type-icon">
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><polygon points="2,0 10,5 2,10" /></svg>
+      </span>
+    {:else if data.nodeType === 'end'}
+      <span class="type-icon">
+        <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor"><rect x="0" y="0" width="8" height="8" rx="1" /></svg>
+      </span>
+    {:else if data.nodeType === 'decision'}
+      <span class="type-icon">
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><polygon points="5,0 10,5 5,10 0,5" /></svg>
+      </span>
+    {/if}
     <span class="node-label">{data.label}</span>
+    {#if isRunning}
+      <span class="status-dot running"></span>
+    {:else if isComplete}
+      <span class="status-dot complete"></span>
+    {:else if isError}
+      <span class="status-dot error"></span>
+    {/if}
   </div>
   {#if data.description}
     <div class="node-desc">{data.description}</div>
@@ -36,22 +48,14 @@
 </div>
 
 {#if showSource}
-  <Handle type="source" position={Position.Bottom} class="handle" />
+  <Handle id="right" type="source" position={Position.Right} class="handle" />
+  <Handle id="bottom-source" type="source" position={Position.Bottom} class="handle handle-loop" />
 {/if}
 
 <style>
-  @keyframes runner-pulse {
-    0%, 100% {
-      box-shadow:
-        0 0 4px rgba(148, 226, 213, 0.3),
-        0 0 12px rgba(148, 226, 213, 0.15);
-    }
-    50% {
-      box-shadow:
-        0 0 8px rgba(148, 226, 213, 0.5),
-        0 0 24px rgba(148, 226, 213, 0.25),
-        0 0 40px rgba(148, 226, 213, 0.1);
-    }
+  @keyframes pulse {
+    0%, 100% { opacity: 0.4; transform: scale(1); }
+    50% { opacity: 1; transform: scale(1.3); }
   }
 
   .workflow-node {
@@ -61,51 +65,23 @@
     text-align: left;
     font-family: system-ui, -apple-system, sans-serif;
     background: oklch(15% 0 150);
-    color: oklch(93% 0.005 50);
-    border: 1.5px solid oklch(25% 0 0);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+    color: oklch(90% 0 0);
+    border: 1px solid oklch(25% 0 0);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
     cursor: pointer;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.15s ease, background 0.15s ease;
   }
 
   .workflow-node:hover {
     border-color: oklch(35% 0 0);
+    background: oklch(17% 0 150);
   }
 
-  .workflow-node[data-type='start'] {
-    border-color: oklch(77% 0.152 181.912);
-    border-radius: 9999px;
-    text-align: center;
-    padding: 10px 24px;
-  }
-  .workflow-node[data-type='start']:hover {
-    border-color: oklch(85% 0.152 181.912);
-  }
-
+  .workflow-node[data-type='start'],
   .workflow-node[data-type='end'] {
-    border-color: oklch(83.92% 0.0901 136.87);
     border-radius: 9999px;
     text-align: center;
     padding: 10px 24px;
-  }
-  .workflow-node[data-type='end']:hover {
-    border-color: oklch(90% 0.0901 136.87);
-  }
-
-  .workflow-node[data-type='action'] {
-    border-color: oklch(25% 0 0);
-  }
-
-  .workflow-node[data-type='decision'] {
-    border-color: oklch(80.39% 0.1148 241.68);
-  }
-  .workflow-node[data-type='decision']:hover {
-    border-color: oklch(88% 0.1148 241.68);
-  }
-
-  .workflow-node.running {
-    border-color: oklch(77% 0.152 181.912);
-    animation: runner-pulse 2.5s ease-in-out infinite;
   }
 
   .node-header {
@@ -119,37 +95,14 @@
     justify-content: center;
   }
 
-  .type-badge {
-    font-size: 10px;
-    width: 20px;
-    height: 20px;
+  .type-icon {
+    width: 16px;
+    height: 16px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 4px;
     flex-shrink: 0;
-    background: oklch(20% 0 150);
-    color: oklch(80% 0 0);
-  }
-
-  .type-badge[data-type='start'] {
-    background: oklch(77% 0.152 181.912 / 0.15);
-    color: oklch(77% 0.152 181.912);
-  }
-
-  .type-badge[data-type='end'] {
-    background: oklch(83.92% 0.0901 136.87 / 0.15);
-    color: oklch(83.92% 0.0901 136.87);
-  }
-
-  .type-badge[data-type='action'] {
-    background: oklch(25% 0 0);
-    color: oklch(80% 0 0);
-  }
-
-  .type-badge[data-type='decision'] {
-    background: oklch(80.39% 0.1148 241.68 / 0.15);
-    color: oklch(80.39% 0.1148 241.68);
+    color: oklch(55% 0 0);
   }
 
   .node-label {
@@ -158,24 +111,45 @@
     line-height: 1.2;
   }
 
-  .node-desc {
-    font-size: 11px;
-    opacity: 0.55;
-    margin-top: 4px;
-    line-height: 1.3;
-    padding-left: 26px;
+  .status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-left: auto;
   }
 
-  [data-type='start'] .node-desc,
-  [data-type='end'] .node-desc {
-    padding-left: 0;
+  .status-dot.running {
+    background: oklch(75% 0.15 160);
+    animation: pulse 2s ease-in-out infinite;
+  }
+
+  .status-dot.complete {
+    background: oklch(70% 0.12 145);
+  }
+
+  .status-dot.error {
+    background: oklch(65% 0.2 25);
+  }
+
+  .node-desc {
+    font-size: 11px;
+    color: oklch(55% 0 0);
+    margin-top: 4px;
+    line-height: 1.3;
   }
 
   :global(.handle) {
-    width: 8px !important;
-    height: 8px !important;
+    width: 6px !important;
+    height: 6px !important;
     background: oklch(25% 0 0) !important;
-    border: 1.5px solid oklch(40% 0 0) !important;
+    border: 1px solid oklch(40% 0 0) !important;
     border-radius: 50% !important;
+  }
+
+  :global(.handle-loop) {
+    width: 5px !important;
+    height: 5px !important;
+    opacity: 0.5;
   }
 </style>

--- a/assets/svelte/WorkflowNode.svelte
+++ b/assets/svelte/WorkflowNode.svelte
@@ -1,0 +1,75 @@
+<script>
+  import { Handle, Position } from '@xyflow/svelte';
+
+  let { data } = $props();
+
+  const showTarget = data.nodeType !== 'start';
+  const showSource = data.nodeType !== 'end';
+</script>
+
+{#if showTarget}
+  <Handle type="target" position={Position.Top} />
+{/if}
+
+<div class="workflow-node" data-type={data.nodeType}>
+  <div class="node-label">{data.label}</div>
+  {#if data.description}
+    <div class="node-desc">{data.description}</div>
+  {/if}
+</div>
+
+{#if showSource}
+  <Handle type="source" position={Position.Bottom} />
+{/if}
+
+<style>
+  .workflow-node {
+    padding: 10px 16px;
+    border-radius: 8px;
+    min-width: 150px;
+    text-align: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+  }
+
+  .workflow-node[data-type='start'] {
+    background: linear-gradient(135deg, #10b981, #059669);
+    color: white;
+    border: 2px solid #047857;
+    border-radius: 9999px;
+    padding: 12px 24px;
+  }
+
+  .workflow-node[data-type='end'] {
+    background: linear-gradient(135deg, #10b981, #059669);
+    color: white;
+    border: 2px solid #047857;
+    border-radius: 9999px;
+    padding: 12px 24px;
+  }
+
+  .workflow-node[data-type='action'] {
+    background: linear-gradient(135deg, #6366f1, #4f46e5);
+    color: white;
+    border: 2px solid #4338ca;
+  }
+
+  .workflow-node[data-type='decision'] {
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    color: white;
+    border: 2px solid #b45309;
+  }
+
+  .node-label {
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 1.2;
+  }
+
+  .node-desc {
+    font-size: 11px;
+    opacity: 0.85;
+    margin-top: 4px;
+    line-height: 1.3;
+  }
+</style>

--- a/assets/svelte/index.js
+++ b/assets/svelte/index.js
@@ -1,0 +1,1 @@
+export { default as App } from "./App.svelte";

--- a/assets/svelte/index.js
+++ b/assets/svelte/index.js
@@ -1,1 +1,2 @@
 export { default as App } from "./App.svelte";
+export { default as WorkflowGraph } from "./WorkflowGraph.svelte";

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -28,7 +28,12 @@ config :citadel, CitadelWeb.Endpoint,
   secret_key_base: "sYKL/CuV5x9ijCYkgRc3cL+NmSmfPCIBCCjN/AyoeIgxLMDI5oFrw/qK8uCJa69X",
   watchers: [
     esbuild: {Esbuild, :install_and_run, [:citadel, ~w(--sourcemap=inline --watch)]},
-    tailwind: {Tailwind, :install_and_run, [:citadel, ~w(--watch)]}
+    tailwind: {Tailwind, :install_and_run, [:citadel, ~w(--watch)]},
+    node: [
+      Path.expand("../assets/build_svelte.js", __DIR__),
+      "--watch",
+      cd: Path.expand("../assets", __DIR__)
+    ]
   ]
 
 config :live_debugger, :disabled?, true
@@ -63,7 +68,8 @@ config :citadel, CitadelWeb.Endpoint,
     patterns: [
       ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",
-      ~r"lib/citadel_web/(?:controllers|live|components|router)/?.*\.(ex|heex)$"
+      ~r"lib/citadel_web/(?:controllers|live|components|router)/?.*\.(ex|heex)$",
+      ~r"assets/svelte/.*(svelte|js)$"
     ]
   ]
 

--- a/lib/citadel_web/live/workflow_editor_live.ex
+++ b/lib/citadel_web/live/workflow_editor_live.ex
@@ -1,0 +1,25 @@
+defmodule CitadelWeb.WorkflowEditorLive do
+  use CitadelWeb, :live_view
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.app
+      flash={@flash}
+      current_workspace={@current_workspace}
+      workspaces={@workspaces}
+      agents={@agents}
+    >
+      <div class="p-6">
+        <h1 class="text-2xl font-bold mb-4">Workflow Editor</h1>
+        <div
+          id="workflow-editor"
+          phx-hook="WorkflowEditor"
+          phx-update="ignore"
+          class="w-full h-[calc(100vh-12rem)]"
+        >
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/citadel_web/live_user_auth.ex
+++ b/lib/citadel_web/live_user_auth.ex
@@ -103,6 +103,21 @@ defmodule CitadelWeb.LiveUserAuth do
     end
   end
 
+  def on_mount(:require_workflow_editor_feature, _params, _session, socket) do
+    case FeatureFlags.get(:workflow_editor) do
+      {:ok, true} ->
+        {:cont, socket}
+
+      _ ->
+        socket =
+          socket
+          |> Phoenix.LiveView.put_flash(:error, "Workflow editor is not available")
+          |> Phoenix.LiveView.redirect(to: ~p"/dashboard")
+
+        {:halt, socket}
+    end
+  end
+
   def on_mount(:set_reset_page_title, _params, _session, socket) do
     {:cont, assign(socket, :page_title, "Reset Password")}
   end

--- a/lib/citadel_web/router.ex
+++ b/lib/citadel_web/router.ex
@@ -198,6 +198,22 @@ defmodule CitadelWeb.Router do
   end
 
   if Application.compile_env(:citadel, :dev_routes) do
+    scope "/dev", CitadelWeb do
+      pipe_through :browser
+
+      ash_authentication_live_session :workflow_editor_routes,
+        on_mount: [
+          {CitadelWeb.LiveUserAuth, :live_user_required},
+          {CitadelWeb.LiveUserAuth, :load_workspace},
+          {CitadelWeb.AgentPresenceHook, :default},
+          {CitadelWeb.LiveUserAuth, :require_workflow_editor_feature}
+        ] do
+        live "/workflow-editor", WorkflowEditorLive
+      end
+    end
+  end
+
+  if Application.compile_env(:citadel, :dev_routes) do
     import AshAdmin.Router
 
     scope "/admin" do

--- a/mix.exs
+++ b/mix.exs
@@ -129,11 +129,21 @@ defmodule Citadel.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ash.setup --quiet", "test"],
-      "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
-      "assets.build": ["compile", "tailwind citadel", "esbuild citadel"],
+      "assets.setup": [
+        "tailwind.install --if-missing",
+        "esbuild.install --if-missing",
+        "cmd npm install --prefix assets"
+      ],
+      "assets.build": [
+        "compile",
+        "tailwind citadel",
+        "esbuild citadel",
+        "cmd node assets/build_svelte.js"
+      ],
       "assets.deploy": [
         "tailwind citadel --minify",
         "esbuild citadel --minify",
+        "cmd node assets/build_svelte.js --minify",
         "phx.digest"
       ],
       precommit: [

--- a/priv/repo/migrations/20260408192340_add_workflow_editor_feature_flag.exs
+++ b/priv/repo/migrations/20260408192340_add_workflow_editor_feature_flag.exs
@@ -1,0 +1,22 @@
+defmodule Citadel.Repo.Migrations.AddWorkflowEditorFeatureFlag do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    INSERT INTO feature_flags (id, key, enabled, description, inserted_at, updated_at)
+    VALUES (
+      uuid_generate_v7(),
+      'workflow_editor',
+      true,
+      'Prototype workflow editor UI',
+      (now() AT TIME ZONE 'utc'),
+      (now() AT TIME ZONE 'utc')
+    )
+    ON CONFLICT (key) DO NOTHING
+    """
+  end
+
+  def down do
+    execute "DELETE FROM feature_flags WHERE key = 'workflow_editor'"
+  end
+end


### PR DESCRIPTION
## Summary

- Add a Node-based esbuild build script (`assets/build_svelte.js`) using `esbuild-svelte` plugin to compile `.svelte` files
- Install npm dependencies: `svelte`, `esbuild-svelte`, `@xyflow/svelte`, `@xyflow/system`, and `dagre`
- Create `assets/svelte/index.js` as the entry point for Svelte components, outputting to `priv/static/assets/js/svelte/`
- Wire a second watcher in `config/dev.exs` to run the Svelte build script alongside the existing esbuild and Tailwind watchers
- Add `assets/svelte/` to live reload patterns so browser refreshes on `.svelte` changes

The existing Elixir esbuild configuration is untouched — the two pipelines run independently. The Svelte bundle uses ESM format to match the existing build output and can be imported from LiveView hooks in `assets/js/hooks/`.

## Test plan

- [ ] `cd assets && npm install` completes without errors
- [ ] `node assets/build_svelte.js` produces a bundle under `priv/static/assets/js/svelte/`
- [ ] `mix phx.server` starts both the existing esbuild watcher and the new Svelte watcher (visible in dev server logs)
- [ ] A trivial Svelte component imported from a LiveView hook mounts and renders correctly in the browser
- [ ] Existing JS/CSS build pipeline (`mix assets.build`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)