### PR TITLE
P-179: Auto-create TaskActivity on agent run creation

### DIFF
--- a/lib/citadel/tasks/agent_run.ex
+++ b/lib/citadel/tasks/agent_run.ex
@@ -24,6 +24,7 @@ defmodule Citadel.Tasks.AgentRun do
 
       change relate_actor(:user)
       change Citadel.Tasks.Changes.InheritTaskWorkspace
+      change Citadel.Tasks.Changes.CreateAgentRunActivity
     end
 
     update :update do
@@ -82,6 +83,7 @@ defmodule Citadel.Tasks.AgentRun do
 
       change relate_actor(:user)
       change Citadel.Tasks.Changes.ClaimNextTask
+      change Citadel.Tasks.Changes.CreateAgentRunActivity
     end
 
     read :list_by_task do

--- a/lib/citadel/tasks/changes/create_agent_run_activity.ex
+++ b/lib/citadel/tasks/changes/create_agent_run_activity.ex
@@ -1,0 +1,16 @@
+defmodule Citadel.Tasks.Changes.CreateAgentRunActivity do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, fn _changeset, agent_run ->
+      Citadel.Tasks.create_agent_run_activity!(
+        %{task_id: agent_run.task_id, agent_run_id: agent_run.id},
+        tenant: agent_run.workspace_id
+      )
+
+      {:ok, agent_run}
+    end)
+  end
+end

--- a/test/citadel/tasks/agent_run_activity_test.exs
+++ b/test/citadel/tasks/agent_run_activity_test.exs
@@ -26,6 +26,72 @@ defmodule Citadel.Tasks.AgentRunActivityTest do
     {:ok, user: user, workspace: workspace, task: task}
   end
 
+  describe "auto-creation of agent run activity" do
+    test "creating an agent run auto-creates a linked TaskActivity", %{
+      user: user,
+      workspace: workspace,
+      task: task
+    } do
+      agent_run =
+        Tasks.create_agent_run!(
+          %{task_id: task.id},
+          actor: user,
+          tenant: workspace.id
+        )
+
+      activities =
+        Tasks.list_task_activities!(task.id, actor: user, tenant: workspace.id)
+
+      assert length(activities) == 1
+      activity = hd(activities)
+      assert activity.type == :agent_run
+      assert activity.actor_type == :ai
+      assert activity.actor_display_name == "Agent"
+      assert activity.task_id == task.id
+      assert activity.agent_run_id == agent_run.id
+      assert activity.workspace_id == workspace.id
+    end
+
+    test "auto-created activity broadcasts PubSub message", %{
+      user: user,
+      workspace: workspace,
+      task: task
+    } do
+      CitadelWeb.Endpoint.subscribe("tasks:task_activities:#{task.id}")
+
+      Tasks.create_agent_run!(
+        %{task_id: task.id},
+        actor: user,
+        tenant: workspace.id
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: "tasks:task_activities:" <> _,
+        event: "create_agent_run_activity"
+      }
+    end
+
+    test "auto-created activity can load agent_run relationship", %{
+      user: user,
+      workspace: workspace,
+      task: task
+    } do
+      agent_run =
+        Tasks.create_agent_run!(
+          %{task_id: task.id},
+          actor: user,
+          tenant: workspace.id
+        )
+
+      activities =
+        Tasks.list_task_activities!(task.id, actor: user, tenant: workspace.id)
+
+      activity = hd(activities)
+      loaded = Ash.load!(activity, :agent_run, authorize?: false, tenant: workspace.id)
+      assert loaded.agent_run.id == agent_run.id
+    end
+  end
+
   describe "create_agent_run_activity/2" do
     test "creates an agent run activity with correct attributes", %{
       user: user,
@@ -86,27 +152,6 @@ defmodule Citadel.Tasks.AgentRunActivityTest do
       assert loaded.agent_run.status == :pending
     end
 
-    test "broadcasts PubSub message on create", %{
-      user: user,
-      workspace: workspace,
-      task: task
-    } do
-      agent_run =
-        generate(agent_run([task_id: task.id], actor: user, tenant: workspace.id))
-
-      CitadelWeb.Endpoint.subscribe("tasks:task_activities:#{task.id}")
-
-      Tasks.create_agent_run_activity!(
-        %{task_id: task.id, agent_run_id: agent_run.id},
-        tenant: workspace.id
-      )
-
-      assert_receive %Phoenix.Socket.Broadcast{
-        topic: "tasks:task_activities:" <> _,
-        event: "create_agent_run_activity"
-      }
-    end
-
     test "bypasses authorization (no actor required)", %{
       user: user,
       workspace: workspace,
@@ -137,13 +182,7 @@ defmodule Citadel.Tasks.AgentRunActivityTest do
         tenant: workspace.id
       )
 
-      agent_run =
-        generate(agent_run([task_id: task.id], actor: user, tenant: workspace.id))
-
-      Tasks.create_agent_run_activity!(
-        %{task_id: task.id, agent_run_id: agent_run.id},
-        tenant: workspace.id
-      )
+      generate(agent_run([task_id: task.id], actor: user, tenant: workspace.id))
 
       Tasks.create_comment!(
         %{body: "Second comment", task_id: task.id},
@@ -167,13 +206,7 @@ defmodule Citadel.Tasks.AgentRunActivityTest do
       workspace: workspace,
       task: task
     } do
-      agent_run =
-        generate(agent_run([task_id: task.id], actor: user, tenant: workspace.id))
-
-      Tasks.create_agent_run_activity!(
-        %{task_id: task.id, agent_run_id: agent_run.id},
-        tenant: workspace.id
-      )
+      generate(agent_run([task_id: task.id], actor: user, tenant: workspace.id))
 
       activities =
         Tasks.list_task_activities!(task.id, actor: user, tenant: workspace.id)
@@ -192,11 +225,6 @@ defmodule Citadel.Tasks.AgentRunActivityTest do
     } do
       agent_run =
         generate(agent_run([task_id: task.id], actor: user, tenant: workspace.id))
-
-      Tasks.create_agent_run_activity!(
-        %{task_id: task.id, agent_run_id: agent_run.id},
-        tenant: workspace.id
-      )
 
       Ash.destroy!(agent_run, authorize?: false, tenant: workspace.id)
 

--- a/test/citadel_web/live/task_live/show_test.exs
+++ b/test/citadel_web/live/task_live/show_test.exs
@@ -1384,17 +1384,9 @@ defmodule CitadelWeb.TaskLive.ShowTest do
   end
 
   defp create_agent_run_with_activity(task, user, workspace) do
-    run =
-      Tasks.create_agent_run!(%{task_id: task.id},
-        actor: user,
-        tenant: workspace.id
-      )
-
-    Tasks.create_agent_run_activity!(%{task_id: task.id, agent_run_id: run.id},
-      authorize?: false,
+    Tasks.create_agent_run!(%{task_id: task.id},
+      actor: user,
       tenant: workspace.id
     )
-
-    run
   end
 end


### PR DESCRIPTION
## Summary

- Auto-create a `TaskActivity` record with `type: :agent_run` when an agent run is created via `create` or `claim_next`
- Ensures agent runs are immediately visible in the activity timeline without waiting for a status change or other update
- Real-time updates as the run progresses (status changes, commits, logs) continue to flow through the existing PubSub mechanism

## Test plan

- [ ] Creating an agent run via `create` produces a linked `TaskActivity` with `type: :agent_run`
- [ ] Creating an agent run via `claim_next` also produces a linked `TaskActivity`
- [ ] The activity appears immediately in the task activity timeline
- [ ] Subsequent agent run updates (status, commits, logs) reflect in real-time via PubSub
- [ ] Existing agent run and task activity tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)