### PR TITLE
P-2: feat: add CreateAgentRunActivity change module

### DIFF
--- a/lib/citadel/tasks/changes/create_agent_run_activity.ex
+++ b/lib/citadel/tasks/changes/create_agent_run_activity.ex
@@ -7,7 +7,8 @@ defmodule Citadel.Tasks.Changes.CreateAgentRunActivity do
     Ash.Changeset.after_action(changeset, fn _changeset, agent_run ->
       Citadel.Tasks.create_agent_run_activity!(
         %{task_id: agent_run.task_id, agent_run_id: agent_run.id},
-        tenant: agent_run.workspace_id
+        tenant: agent_run.workspace_id,
+        authorize?: false
       )
 
       {:ok, agent_run}


### PR DESCRIPTION
## Summary

Adds `Citadel.Tasks.Changes.CreateAgentRunActivity`, an Ash change module that automatically creates a `TaskActivity` record after an `AgentRun` is persisted. This makes every agent run immediately visible in the task activity timeline without requiring callers to manually trigger the activity creation.

## What changed

- New file: `lib/citadel/tasks/changes/create_agent_run_activity.ex`
  - Implements `Ash.Resource.Change` behavior
  - Uses `Ash.Changeset.after_action/2` to fire after the agent run is successfully saved
  - Calls `Citadel.Tasks.create_agent_run_activity!` with the new agent run's `task_id`, `agent_run_id`, and `workspace_id` as tenant
  - Passes `authorize?: false` since the `create_agent_run_activity` action has a bypass policy
  - Returns `{:ok, agent_run}` unmodified — does not alter the agent run result

## Why

The `create_agent_run_activity` action on `TaskActivity` existed but was never called from application code, meaning agent runs were not appearing in the activity timeline. This change wires that action into the agent run creation flow via a reusable change module, following the existing pattern used by `SyncWorkItemStatus` and `ClaimNextTask`.