### PR TITLE
P-98: Add CitadelAgent.TaskRunner GenServer

### DIFF
--- a/citadel_agent/lib/citadel_agent/application.ex
+++ b/citadel_agent/lib/citadel_agent/application.ex
@@ -11,8 +11,8 @@ defmodule CitadelAgent.Application do
 
         [
           {Registry, keys: :unique, name: CitadelAgent.RunnerRegistry},
-          {DynamicSupervisor, name: CitadelAgent.RunnerSupervisor, strategy: :one_for_one},
           {CitadelAgent.Socket, []},
+          {DynamicSupervisor, name: CitadelAgent.TaskRunnerSupervisor, strategy: :one_for_one},
           {CitadelAgent.Scheduler, []}
         ]
       else

--- a/citadel_agent/lib/citadel_agent/application.ex
+++ b/citadel_agent/lib/citadel_agent/application.ex
@@ -13,7 +13,7 @@ defmodule CitadelAgent.Application do
           {Registry, keys: :unique, name: CitadelAgent.RunnerRegistry},
           {DynamicSupervisor, name: CitadelAgent.RunnerSupervisor, strategy: :one_for_one},
           {CitadelAgent.Socket, []},
-          {CitadelAgent.Worker, []}
+          {CitadelAgent.Scheduler, []}
         ]
       else
         []

--- a/citadel_agent/lib/citadel_agent/application.ex
+++ b/citadel_agent/lib/citadel_agent/application.ex
@@ -3,39 +3,23 @@ defmodule CitadelAgent.Application do
 
   use Application
 
-  require Logger
-
   @impl true
   def start(_type, _args) do
-    children = boot_children()
+    children =
+      if CitadelAgent.config(:api_key) do
+        CitadelAgent.Preflight.run!()
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: CitadelAgent.Supervisor)
-  end
-
-  defp boot_children do
-    cond do
-      not running_as_release?() ->
+        [
+          {Registry, keys: :unique, name: CitadelAgent.RunnerRegistry},
+          {DynamicSupervisor, name: CitadelAgent.RunnerSupervisor, strategy: :one_for_one},
+          {CitadelAgent.Socket, []},
+          {CitadelAgent.Worker, []}
+        ]
+      else
         []
+      end
 
-      is_nil(CitadelAgent.config(:api_key)) ->
-        IO.puts(:stderr, "CITADEL_API_KEY is not set. Refusing to start.")
-        System.halt(1)
-
-      true ->
-        try do
-          CitadelAgent.Preflight.run!()
-
-          [
-            {CitadelAgent.Socket, []},
-            {CitadelAgent.Worker, []}
-          ]
-        rescue
-          e in CitadelAgent.Preflight.CheckError ->
-            IO.puts(:stderr, "Preflight failed: #{Exception.message(e)}")
-            System.halt(1)
-        end
-    end
+    opts = [strategy: :one_for_one, name: CitadelAgent.Supervisor]
+    Supervisor.start_link(children, opts)
   end
-
-  defp running_as_release?, do: not is_nil(System.get_env("RELEASE_NAME"))
 end

--- a/citadel_agent/lib/citadel_agent/client.ex
+++ b/citadel_agent/lib/citadel_agent/client.ex
@@ -81,14 +81,24 @@ defmodule CitadelAgent.Client do
   defp api_key, do: CitadelAgent.config(:api_key)
 
   defp base_req do
-    Req.new(
-      base_url: base_url(),
-      headers: [
-        {"authorization", "Bearer #{api_key()}"},
-        {"content-type", "application/json"},
-        {"accept", "application/json"}
-      ]
-    )
+    opts =
+      Keyword.merge(
+        [
+          base_url: base_url(),
+          headers: [
+            {"authorization", "Bearer #{api_key()}"},
+            {"content-type", "application/json"},
+            {"accept", "application/json"}
+          ]
+        ],
+        req_options()
+      )
+
+    Req.new(opts)
+  end
+
+  defp req_options do
+    Application.get_env(:citadel_agent, :client_req_options, [])
   end
 
   defp req_get(path) do

--- a/citadel_agent/lib/citadel_agent/runners.ex
+++ b/citadel_agent/lib/citadel_agent/runners.ex
@@ -1,0 +1,26 @@
+defmodule CitadelAgent.Runners do
+  @moduledoc """
+  Helper functions for querying the RunnerRegistry to determine the status
+  of active TaskRunner processes.
+  """
+
+  @registry CitadelAgent.RunnerRegistry
+
+  def get_status do
+    case Registry.select(@registry, [{{:"$1", :_, :_}, [], [:"$1"]}]) do
+      [] -> {"idle", nil}
+      [task_id | _] -> {"working", task_id}
+    end
+  end
+
+  def has_active_runner? do
+    Registry.count(@registry) > 0
+  end
+
+  def lookup(task_id) do
+    case Registry.lookup(@registry, task_id) do
+      [{pid, _value}] -> pid
+      [] -> nil
+    end
+  end
+end

--- a/citadel_agent/lib/citadel_agent/scheduler.ex
+++ b/citadel_agent/lib/citadel_agent/scheduler.ex
@@ -1,4 +1,4 @@
-defmodule CitadelAgent.Worker do
+defmodule CitadelAgent.Scheduler do
   @moduledoc """
   GenServer that polls Citadel for agent-eligible tasks and spawns a
   `CitadelAgent.TaskRunner` process for each claimed task.
@@ -17,7 +17,7 @@ defmodule CitadelAgent.Worker do
     poll_interval = CitadelAgent.config(:poll_interval) || 10_000
     send(self(), :poll)
 
-    Logger.info("CitadelAgent.Worker started, polling every #{poll_interval}ms")
+    Logger.info("CitadelAgent.Scheduler started, polling every #{poll_interval}ms")
 
     {:ok, %{poll_interval: poll_interval}}
   end

--- a/citadel_agent/lib/citadel_agent/scheduler.ex
+++ b/citadel_agent/lib/citadel_agent/scheduler.ex
@@ -73,7 +73,7 @@ defmodule CitadelAgent.Scheduler do
           %{task: task, run: run, project_path: project_path, work_item: work_item}
         }
 
-        case DynamicSupervisor.start_child(CitadelAgent.RunnerSupervisor, child_spec) do
+        case DynamicSupervisor.start_child(CitadelAgent.TaskRunnerSupervisor, child_spec) do
           {:ok, pid} ->
             Logger.info("Started TaskRunner #{inspect(pid)} for task #{task["human_id"]}")
 

--- a/citadel_agent/lib/citadel_agent/socket.ex
+++ b/citadel_agent/lib/citadel_agent/socket.ex
@@ -53,12 +53,15 @@ defmodule CitadelAgent.Socket do
   def handle_connect(socket) do
     Logger.info("Connected to Citadel WebSocket, joining agent channel")
 
-    {:ok,
-     join(socket, "agents:lobby", %{
-       "agent_name" => socket.assigns.agent_name,
-       "status" => socket.assigns.status,
-       "current_task_id" => socket.assigns.current_task_id
-     })}
+    {status, task_id} = CitadelAgent.Runners.get_status()
+
+    payload = %{
+      "agent_name" => socket.assigns.agent_name,
+      "status" => status,
+      "current_task_id" => task_id
+    }
+
+    {:ok, join(socket, "agents:lobby", payload)}
   end
 
   @impl true
@@ -70,10 +73,17 @@ defmodule CitadelAgent.Socket do
       "Joined agent channel for workspace #{workspace_id} (max run: #{max_run_seconds}s)"
     )
 
+    {status, task_id} = CitadelAgent.Runners.get_status()
+
     socket =
       socket
       |> assign(:workspace_id, workspace_id)
       |> assign(:max_run_seconds, max_run_seconds)
+
+    push(socket, "agents:lobby", "update_status", %{
+      "status" => status,
+      "current_task_id" => task_id
+    })
 
     {:ok, socket}
   end

--- a/citadel_agent/lib/citadel_agent/task_runner.ex
+++ b/citadel_agent/lib/citadel_agent/task_runner.ex
@@ -1,0 +1,43 @@
+defmodule CitadelAgent.TaskRunner do
+  @moduledoc """
+  A GenServer that wraps task execution, registering itself in the RunnerRegistry
+  via `:via` tuple naming. When the process terminates for any reason, the Registry
+  automatically deregisters it.
+  """
+
+  use GenServer
+
+  require Logger
+
+  def start_link(args) do
+    task_id = Keyword.fetch!(args, :task_id)
+
+    GenServer.start_link(__MODULE__, args,
+      name: {:via, Registry, {CitadelAgent.RunnerRegistry, task_id}}
+    )
+  end
+
+  @impl true
+  def init(args) do
+    task = Keyword.fetch!(args, :task)
+    project_path = Keyword.fetch!(args, :project_path)
+    task_id = Keyword.fetch!(args, :task_id)
+
+    {:ok, %{task: task, project_path: project_path, task_id: task_id, result: nil},
+     {:continue, :execute}}
+  end
+
+  @impl true
+  def handle_continue(:execute, state) do
+    result = CitadelAgent.Runner.execute(state.task, state.project_path)
+    {:stop, {:shutdown, result}, %{state | result: result}}
+  rescue
+    e ->
+      {:stop, {:shutdown, {:error, Exception.message(e)}}, state}
+  end
+
+  @impl true
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+end

--- a/citadel_agent/lib/citadel_agent/task_runner.ex
+++ b/citadel_agent/lib/citadel_agent/task_runner.ex
@@ -1,43 +1,195 @@
 defmodule CitadelAgent.TaskRunner do
   @moduledoc """
-  A GenServer that wraps task execution, registering itself in the RunnerRegistry
-  via `:via` tuple naming. When the process terminates for any reason, the Registry
-  automatically deregisters it.
+  GenServer that wraps the execution of a single task. Owns the full lifecycle
+  of one task run: fetching feedback, pushing status updates, executing via
+  `Runner.execute/3`, reporting results, transitioning the task state, and
+  cleaning up.
+
+  Registers itself in the RunnerRegistry via `:via` tuple naming so the
+  Registry automatically deregisters the process on termination.
   """
 
-  use GenServer
+  use GenServer, restart: :temporary
 
   require Logger
 
-  def start_link(args) do
-    task_id = Keyword.fetch!(args, :task_id)
+  def start_link(%{task: task, run: run, project_path: project_path} = args) do
+    task_id = task["id"]
 
-    GenServer.start_link(__MODULE__, args,
+    GenServer.start_link(
+      __MODULE__,
+      %{
+        task: task,
+        run: run,
+        project_path: project_path,
+        work_item: Map.get(args, :work_item)
+      },
       name: {:via, Registry, {CitadelAgent.RunnerRegistry, task_id}}
     )
   end
 
   @impl true
-  def init(args) do
-    task = Keyword.fetch!(args, :task)
-    project_path = Keyword.fetch!(args, :project_path)
-    task_id = Keyword.fetch!(args, :task_id)
+  def init(state) do
+    CitadelAgent.Socket.update_status("working", state.task["id"])
+    send(self(), :execute)
 
-    {:ok, %{task: task, project_path: project_path, task_id: task_id, result: nil},
-     {:continue, :execute}}
+    {:ok, Map.put(state, :active_run, state.run)}
   end
 
   @impl true
-  def handle_continue(:execute, state) do
-    result = CitadelAgent.Runner.execute(state.task, state.project_path)
-    {:stop, {:shutdown, result}, %{state | result: result}}
+  def handle_info(:execute, state) do
+    state = run_task(state)
+    CitadelAgent.Socket.update_status("idle")
+    {:stop, :normal, %{state | active_run: nil}}
+  end
+
+  @impl true
+  def terminate(:normal, _state), do: :ok
+
+  def terminate(reason, %{active_run: %{"id" => run_id}} = _state) do
+    Logger.error("TaskRunner terminating with active run #{run_id}, marking as failed")
+
+    CitadelAgent.Client.update_run(run_id, %{
+      "status" => "failed",
+      "error_message" => "TaskRunner process terminated: #{inspect(reason)}",
+      "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+    })
+
+    CitadelAgent.Socket.update_status("idle")
+  end
+
+  def terminate(_reason, _state) do
+    CitadelAgent.Socket.update_status("idle")
+  end
+
+  defp run_task(state) do
+    %{task: task, run: run, project_path: project_path, work_item: work_item} = state
+    run_id = run["id"]
+    feedback = fetch_feedback(work_item)
+    resume_session_id = fetch_resume_session_id(work_item)
+
+    case CitadelAgent.Runner.execute(task, project_path,
+           run_id: run_id,
+           feedback: feedback,
+           resume_session_id: resume_session_id
+         ) do
+      {:ok, result} ->
+        case CitadelAgent.Client.update_run(run_id, %{
+               "status" => result.status,
+               "commits" => result.commits,
+               "logs" => result.logs,
+               "test_output" => result.test_output,
+               "session_id" => result.session_id,
+               "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+             }) do
+          {:ok, %{"status" => "completed"}} ->
+            transition_task_to_in_review(task)
+
+          {:ok, _run} ->
+            Logger.info(
+              "Task #{task["human_id"]} run ended with non-completed status, skipping In Review"
+            )
+
+          {:error, reason} ->
+            Logger.error("Failed to update run #{run_id}: #{inspect(reason)}")
+        end
+
+        Logger.info("Task #{task["human_id"]} completed with status: #{result.status}")
+        push_stream_complete(run_id)
+
+        %{state | active_run: nil}
+
+      {:error, reason} ->
+        CitadelAgent.Client.update_run(run_id, %{
+          "status" => "failed",
+          "error_message" => inspect(reason),
+          "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+        })
+
+        Logger.error("Task #{task["human_id"]} failed: #{inspect(reason)}")
+        push_stream_complete(run_id)
+
+        %{state | active_run: nil}
+    end
   rescue
-    e ->
-      {:stop, {:shutdown, {:error, Exception.message(e)}}, state}
+    exception ->
+      Logger.error(
+        "Task #{state.task["human_id"]} crashed: #{Exception.format(:error, exception, __STACKTRACE__)}"
+      )
+
+      CitadelAgent.Client.update_run(state.run["id"], %{
+        "status" => "failed",
+        "error_message" => Exception.message(exception),
+        "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+      })
+
+      push_stream_complete(state.run["id"])
+
+      %{state | active_run: nil}
   end
 
-  @impl true
-  def handle_info(_msg, state) do
-    {:noreply, state}
+  defp push_stream_complete(run_id) do
+    CitadelAgent.Socket.push_stream_complete(run_id)
+  rescue
+    e -> Logger.debug("Failed to push stream_complete: #{Exception.message(e)}")
+  end
+
+  defp fetch_feedback(%{"type" => "changes_requested", "comment_id" => comment_id})
+       when is_binary(comment_id) do
+    fetch_comment_body(comment_id)
+  end
+
+  defp fetch_feedback(%{"type" => "question_answered", "comment_id" => comment_id})
+       when is_binary(comment_id) do
+    fetch_comment_body(comment_id)
+  end
+
+  defp fetch_feedback(_work_item), do: nil
+
+  defp fetch_comment_body(comment_id) do
+    case CitadelAgent.Client.fetch_comment(comment_id) do
+      {:ok, %{"body" => body}} when is_binary(body) ->
+        Logger.info("Fetched feedback comment #{comment_id}")
+        body
+
+      {:ok, _} ->
+        Logger.warning("Comment #{comment_id} had no body, proceeding without feedback")
+        nil
+
+      {:error, reason} ->
+        Logger.warning(
+          "Failed to fetch comment #{comment_id}: #{inspect(reason)}, proceeding without feedback"
+        )
+
+        nil
+    end
+  end
+
+  defp fetch_resume_session_id(%{"type" => "question_answered", "session_id" => session_id})
+       when is_binary(session_id) do
+    session_id
+  end
+
+  defp fetch_resume_session_id(_work_item), do: nil
+
+  defp transition_task_to_in_review(task) do
+    with {:ok, states} <- CitadelAgent.Client.fetch_task_states(),
+         %{"id" => state_id} <- Enum.find(states, &(&1["name"] == "In Review")) do
+      case CitadelAgent.Client.update_task_state(task["id"], state_id) do
+        {:ok, _task} ->
+          Logger.info("Task #{task["human_id"]} transitioned to In Review")
+
+        {:error, reason} ->
+          Logger.warning(
+            "Failed to transition task #{task["human_id"]} to In Review: #{inspect(reason)}"
+          )
+      end
+    else
+      nil ->
+        Logger.warning("Could not find 'In Review' task state")
+
+      {:error, reason} ->
+        Logger.warning("Failed to fetch task states: #{inspect(reason)}")
+    end
   end
 end

--- a/citadel_agent/lib/citadel_agent/worker.ex
+++ b/citadel_agent/lib/citadel_agent/worker.ex
@@ -1,9 +1,7 @@
 defmodule CitadelAgent.Worker do
   @moduledoc """
-  GenServer that polls Citadel for agent-eligible tasks and executes them.
-
-  Tracks the active AgentRun in state so that `terminate/2` can mark it as
-  failed if the process crashes unexpectedly.
+  GenServer that polls Citadel for agent-eligible tasks and spawns a
+  `CitadelAgent.TaskRunner` process for each claimed task.
   """
 
   use GenServer
@@ -21,54 +19,44 @@ defmodule CitadelAgent.Worker do
 
     Logger.info("CitadelAgent.Worker started, polling every #{poll_interval}ms")
 
-    {:ok, %{poll_interval: poll_interval, active_run: nil}}
+    {:ok, %{poll_interval: poll_interval}}
   end
 
   @impl true
   def handle_info(:poll, state) do
-    state = process_next_task(state)
+    process_next_task()
     schedule_poll(state.poll_interval)
     {:noreply, state}
   end
-
-  @impl true
-  def terminate(reason, %{active_run: %{"id" => run_id}}) do
-    Logger.error("Worker terminating with active run #{run_id}, marking as failed")
-
-    CitadelAgent.Client.update_run(run_id, %{
-      "status" => "failed",
-      "error_message" => "Worker process terminated: #{inspect(reason)}",
-      "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
-    })
-  end
-
-  def terminate(_reason, _state), do: :ok
 
   defp schedule_poll(interval) do
     Process.send_after(self(), :poll, interval)
   end
 
-  defp process_next_task(state) do
+  defp process_next_task do
+    if CitadelAgent.Runners.has_active_runner?() do
+      Logger.debug("Runner already active, skipping poll")
+    else
+      claim_and_spawn()
+    end
+  end
+
+  defp claim_and_spawn do
     case CitadelAgent.Client.claim_task() do
       {:ok, nil} ->
         Logger.debug("No agent-eligible tasks available")
         CitadelAgent.Socket.update_status("idle")
-        state
 
       {:ok, %{"task" => task, "agent_run" => run} = claim} ->
         Logger.info("Claimed task #{task["human_id"]}: #{task["title"]}")
-        work_item = claim["work_item"]
-        feedback = fetch_feedback(work_item)
-        resume_session_id = fetch_resume_session_id(work_item)
-        execute_task(task, run, feedback, resume_session_id, state)
+        spawn_runner(task, run, claim["work_item"])
 
       {:error, reason} ->
         Logger.error("Failed to claim task: #{inspect(reason)}")
-        state
     end
   end
 
-  defp execute_task(task, run, feedback, resume_session_id, state) do
+  defp spawn_runner(task, run, work_item) do
     case CitadelAgent.config(:project_path) do
       nil ->
         Logger.error("No project_path configured, failing task #{task["human_id"]}")
@@ -79,138 +67,21 @@ defmodule CitadelAgent.Worker do
           "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
         })
 
-        state
-
       project_path ->
-        state = %{state | active_run: run}
-        CitadelAgent.Socket.update_status("working", task["id"])
-        run_task(task, run, feedback, resume_session_id, project_path)
-        CitadelAgent.Socket.update_status("idle")
-        %{state | active_run: nil}
-    end
-  end
+        child_spec = {
+          CitadelAgent.TaskRunner,
+          %{task: task, run: run, project_path: project_path, work_item: work_item}
+        }
 
-  defp run_task(task, run, feedback, resume_session_id, project_path) do
-    run_id = run["id"]
-
-    case CitadelAgent.Runner.execute(task, project_path,
-           run_id: run_id,
-           feedback: feedback,
-           resume_session_id: resume_session_id
-         ) do
-      {:ok, result} ->
-        case CitadelAgent.Client.update_run(run_id, %{
-               "status" => result.status,
-               "commits" => result.commits,
-               "logs" => result.logs,
-               "test_output" => result.test_output,
-               "session_id" => result.session_id,
-               "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
-             }) do
-          {:ok, %{"status" => "completed"}} ->
-            transition_task_to_in_review(task)
-
-          {:ok, _run} ->
-            Logger.info(
-              "Task #{task["human_id"]} run ended with non-completed status, skipping In Review"
-            )
+        case DynamicSupervisor.start_child(CitadelAgent.RunnerSupervisor, child_spec) do
+          {:ok, pid} ->
+            Logger.info("Started TaskRunner #{inspect(pid)} for task #{task["human_id"]}")
 
           {:error, reason} ->
-            Logger.error("Failed to update run #{run_id}: #{inspect(reason)}")
+            Logger.error(
+              "Failed to start TaskRunner for task #{task["human_id"]}: #{inspect(reason)}"
+            )
         end
-
-        Logger.info("Task #{task["human_id"]} completed with status: #{result.status}")
-        push_stream_complete(run_id)
-
-      {:error, reason} ->
-        CitadelAgent.Client.update_run(run_id, %{
-          "status" => "failed",
-          "error_message" => inspect(reason),
-          "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
-        })
-
-        Logger.error("Task #{task["human_id"]} failed: #{inspect(reason)}")
-        push_stream_complete(run_id)
-    end
-  rescue
-    exception ->
-      Logger.error(
-        "Task #{task["human_id"]} crashed: #{Exception.format(:error, exception, __STACKTRACE__)}"
-      )
-
-      CitadelAgent.Client.update_run(run["id"], %{
-        "status" => "failed",
-        "error_message" => Exception.message(exception),
-        "completed_at" => DateTime.utc_now() |> DateTime.to_iso8601()
-      })
-
-      push_stream_complete(run["id"])
-  end
-
-  defp push_stream_complete(run_id) do
-    try do
-      CitadelAgent.Socket.push_stream_complete(run_id)
-    rescue
-      e -> Logger.debug("Failed to push stream_complete: #{Exception.message(e)}")
-    end
-  end
-
-  defp fetch_feedback(%{"type" => "changes_requested", "comment_id" => comment_id})
-       when is_binary(comment_id) do
-    fetch_comment_body(comment_id)
-  end
-
-  defp fetch_feedback(%{"type" => "question_answered", "comment_id" => comment_id})
-       when is_binary(comment_id) do
-    fetch_comment_body(comment_id)
-  end
-
-  defp fetch_feedback(_work_item), do: nil
-
-  defp fetch_comment_body(comment_id) do
-    case CitadelAgent.Client.fetch_comment(comment_id) do
-      {:ok, %{"body" => body}} when is_binary(body) ->
-        Logger.info("Fetched feedback comment #{comment_id}")
-        body
-
-      {:ok, _} ->
-        Logger.warning("Comment #{comment_id} had no body, proceeding without feedback")
-        nil
-
-      {:error, reason} ->
-        Logger.warning(
-          "Failed to fetch comment #{comment_id}: #{inspect(reason)}, proceeding without feedback"
-        )
-
-        nil
-    end
-  end
-
-  defp fetch_resume_session_id(%{"type" => "question_answered", "session_id" => session_id})
-       when is_binary(session_id) do
-    session_id
-  end
-
-  defp fetch_resume_session_id(_work_item), do: nil
-
-  defp transition_task_to_in_review(task) do
-    with {:ok, states} <- CitadelAgent.Client.fetch_task_states(),
-         %{"id" => state_id} <- Enum.find(states, &(&1["name"] == "In Review")) do
-      case CitadelAgent.Client.update_task_state(task["id"], state_id) do
-        {:ok, _task} ->
-          Logger.info("Task #{task["human_id"]} transitioned to In Review")
-
-        {:error, reason} ->
-          Logger.warning(
-            "Failed to transition task #{task["human_id"]} to In Review: #{inspect(reason)}"
-          )
-      end
-    else
-      nil ->
-        Logger.warning("Could not find 'In Review' task state")
-
-      {:error, reason} ->
-        Logger.warning("Failed to fetch task states: #{inspect(reason)}")
     end
   end
 end

--- a/citadel_agent/lib/mix/tasks/citadel_agent.run.ex
+++ b/citadel_agent/lib/mix/tasks/citadel_agent.run.ex
@@ -42,12 +42,8 @@ defmodule Mix.Tasks.CitadelAgent.Run do
     if opts[:preflight_only] do
       Mix.shell().info("Preflight checks passed. Exiting.")
     else
-      unless Process.whereis(CitadelAgent.Socket) do
-        Supervisor.start_child(CitadelAgent.Supervisor, {CitadelAgent.Socket, []})
-      end
-
-      unless Process.whereis(CitadelAgent.Worker) do
-        Supervisor.start_child(CitadelAgent.Supervisor, {CitadelAgent.Worker, []})
+      unless Process.whereis(CitadelAgent.Scheduler) do
+        CitadelAgent.Scheduler.start_link()
       end
 
       Mix.shell().info("CitadelAgent is running. Press Ctrl+C to stop.")

--- a/citadel_agent/test/citadel_agent/runner_pr_description_test.exs
+++ b/citadel_agent/test/citadel_agent/runner_pr_description_test.exs
@@ -29,7 +29,7 @@ defmodule CitadelAgent.RunnerPrDescriptionTest do
       }
 
       assert {:ok, description} = CitadelAgent.Runner.generate_pr_description(task, project_path)
-      assert description =~ "Fix login bug"
+      assert String.downcase(description) =~ "fix login bug"
     end
 
     test "handles task with nil title gracefully", %{project_path: project_path} do

--- a/citadel_agent/test/citadel_agent/runner_pr_test.exs
+++ b/citadel_agent/test/citadel_agent/runner_pr_test.exs
@@ -206,7 +206,7 @@ defmodule CitadelAgent.RunnerPRTest do
       assert result.status == "completed"
     end
 
-    test "standalone task does not trigger PR creation", %{project_path: project_path} do
+    test "standalone task creates PR from task branch", %{project_path: project_path} do
       test_pid = self()
 
       Req.Test.stub(:github_pr, fn conn ->
@@ -238,7 +238,9 @@ defmodule CitadelAgent.RunnerPRTest do
       assert {:ok, result} = CitadelAgent.Runner.execute(task, project_path)
       assert result.status == "completed"
 
-      refute_received {:pr_created, _}
+      assert_received {:pr_created, body}
+      assert body["head"] == "citadel/task-P-230"
+      assert body["base"] == "main"
     end
   end
 end

--- a/citadel_agent/test/citadel_agent/runner_test.exs
+++ b/citadel_agent/test/citadel_agent/runner_test.exs
@@ -4,15 +4,23 @@ defmodule CitadelAgent.RunnerTest do
   @moduletag :tmp_dir
 
   setup %{tmp_dir: tmp_dir} do
-    System.cmd("git", ["init", "-b", "main"], cd: tmp_dir)
-    System.cmd("git", ["config", "user.email", "test@test.com"], cd: tmp_dir)
-    System.cmd("git", ["config", "user.name", "Test"], cd: tmp_dir)
+    project_path = Path.join(tmp_dir, "project")
+    File.mkdir_p!(project_path)
 
-    File.write!(Path.join(tmp_dir, "README.md"), "# Test")
-    System.cmd("git", ["add", "."], cd: tmp_dir)
-    System.cmd("git", ["commit", "-m", "initial"], cd: tmp_dir)
+    System.cmd("git", ["init", "-b", "main"], cd: project_path)
+    System.cmd("git", ["config", "user.email", "test@test.com"], cd: project_path)
+    System.cmd("git", ["config", "user.name", "Test"], cd: project_path)
 
-    {:ok, project_path: tmp_dir}
+    File.write!(Path.join(project_path, "README.md"), "# Test")
+    System.cmd("git", ["add", "."], cd: project_path)
+    System.cmd("git", ["commit", "-m", "initial"], cd: project_path)
+
+    bare_path = Path.join(tmp_dir, "remote.git")
+    System.cmd("git", ["init", "--bare", bare_path])
+    System.cmd("git", ["remote", "add", "origin", bare_path], cd: project_path)
+    System.cmd("git", ["push", "-u", "origin", "main"], cd: project_path)
+
+    {:ok, project_path: project_path}
   end
 
   describe "worktree creation" do

--- a/citadel_agent/test/citadel_agent/runners_test.exs
+++ b/citadel_agent/test/citadel_agent/runners_test.exs
@@ -1,0 +1,128 @@
+defmodule CitadelAgent.RunnersTest do
+  use ExUnit.Case, async: false
+
+  alias CitadelAgent.Runners
+
+  setup do
+    registry = CitadelAgent.RunnerRegistry
+
+    case GenServer.whereis(registry) do
+      nil ->
+        start_supervised!({Registry, keys: :unique, name: registry})
+
+      _pid ->
+        :ok
+    end
+
+    :ok
+  end
+
+  test "get_status/0 returns idle when no runners are active" do
+    assert {"idle", nil} = Runners.get_status()
+  end
+
+  test "get_status/0 returns working when a runner is active" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+    pid = start_registered_process(task_id)
+
+    assert {"working", ^task_id} = Runners.get_status()
+
+    stop_process(pid)
+  end
+
+  test "get_status/0 returns idle after runner terminates" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+    pid = start_registered_process(task_id)
+    stop_process(pid)
+
+    assert {"idle", nil} = Runners.get_status()
+  end
+
+  test "has_active_runner?/0 returns false when no runners" do
+    refute Runners.has_active_runner?()
+  end
+
+  test "has_active_runner?/0 returns true when a runner exists" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+    pid = start_registered_process(task_id)
+
+    assert Runners.has_active_runner?()
+
+    stop_process(pid)
+  end
+
+  test "has_active_runner?/0 returns false after runner crashes" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+    pid = start_registered_process(task_id)
+
+    kill_and_wait(pid)
+
+    refute Runners.has_active_runner?()
+  end
+
+  test "lookup/1 returns pid for active runner" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+    pid = start_registered_process(task_id)
+
+    assert Runners.lookup(task_id) == pid
+
+    stop_process(pid)
+  end
+
+  test "lookup/1 returns nil for unknown task" do
+    assert Runners.lookup("nonexistent") == nil
+  end
+
+  test "lookup/1 returns nil after runner terminates" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+    pid = start_registered_process(task_id)
+    stop_process(pid)
+
+    assert Runners.lookup(task_id) == nil
+  end
+
+  test "crashed runner does not leave stale entries" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+    pid = start_registered_process(task_id)
+
+    kill_and_wait(pid)
+
+    assert {"idle", nil} = Runners.get_status()
+    refute Runners.has_active_runner?()
+    assert Runners.lookup(task_id) == nil
+  end
+
+  defp start_registered_process(task_id) do
+    {:ok, pid} =
+      Agent.start(fn -> :running end,
+        name: {:via, Registry, {CitadelAgent.RunnerRegistry, task_id}}
+      )
+
+    pid
+  end
+
+  defp stop_process(pid) do
+    ref = Process.monitor(pid)
+    Agent.stop(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    after
+      1_000 -> raise "Process did not stop in time"
+    end
+  end
+
+  defp kill_and_wait(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    after
+      1_000 -> raise "Process did not terminate"
+    end
+
+    # Give Registry time to process its own DOWN monitor
+    Process.sleep(10)
+  end
+end

--- a/citadel_agent/test/citadel_agent/runners_test.exs
+++ b/citadel_agent/test/citadel_agent/runners_test.exs
@@ -110,6 +110,8 @@ defmodule CitadelAgent.RunnersTest do
     after
       1_000 -> raise "Process did not stop in time"
     end
+
+    Process.sleep(10)
   end
 
   defp kill_and_wait(pid) do

--- a/citadel_agent/test/citadel_agent/scheduler_test.exs
+++ b/citadel_agent/test/citadel_agent/scheduler_test.exs
@@ -1,0 +1,192 @@
+defmodule CitadelAgent.SchedulerTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :tmp_dir
+
+  setup :set_req_test_from_context
+
+  setup %{tmp_dir: tmp_dir} do
+    System.cmd("git", ["init", "-b", "main"], cd: tmp_dir)
+    System.cmd("git", ["config", "user.email", "test@test.com"], cd: tmp_dir)
+    System.cmd("git", ["config", "user.name", "Test"], cd: tmp_dir)
+    File.write!(Path.join(tmp_dir, "README.md"), "# Test")
+    System.cmd("git", ["add", "."], cd: tmp_dir)
+    System.cmd("git", ["commit", "-m", "initial"], cd: tmp_dir)
+
+    registry = CitadelAgent.RunnerRegistry
+
+    case GenServer.whereis(registry) do
+      nil -> start_supervised!({Registry, keys: :unique, name: registry})
+      _pid -> :ok
+    end
+
+    sup = CitadelAgent.TaskRunnerSupervisor
+
+    case GenServer.whereis(sup) do
+      nil -> start_supervised!({DynamicSupervisor, name: sup, strategy: :one_for_one})
+      _pid -> :ok
+    end
+
+    app_supervisor_running? = GenServer.whereis(CitadelAgent.Supervisor) != nil
+
+    if app_supervisor_running? do
+      Supervisor.terminate_child(CitadelAgent.Supervisor, CitadelAgent.Scheduler)
+    end
+
+    original_url = CitadelAgent.config(:citadel_url)
+    original_path = CitadelAgent.config(:project_path)
+    original_interval = CitadelAgent.config(:poll_interval)
+    original_api_key = CitadelAgent.config(:api_key)
+    original_req_opts = Application.get_env(:citadel_agent, :client_req_options)
+
+    Application.put_env(:citadel_agent, :citadel_url, "http://localhost:4000")
+    Application.put_env(:citadel_agent, :project_path, tmp_dir)
+    Application.put_env(:citadel_agent, :poll_interval, 600_000)
+    Application.put_env(:citadel_agent, :api_key, "test-key")
+    Application.put_env(:citadel_agent, :client_req_options, plug: {Req.Test, :citadel_api})
+
+    on_exit(fn ->
+      Application.put_env(:citadel_agent, :citadel_url, original_url)
+      Application.put_env(:citadel_agent, :project_path, original_path)
+      Application.put_env(:citadel_agent, :poll_interval, original_interval)
+      Application.put_env(:citadel_agent, :api_key, original_api_key)
+
+      if original_req_opts do
+        Application.put_env(:citadel_agent, :client_req_options, original_req_opts)
+      else
+        Application.delete_env(:citadel_agent, :client_req_options)
+      end
+
+      if app_supervisor_running? do
+        Supervisor.restart_child(CitadelAgent.Supervisor, CitadelAgent.Scheduler)
+      end
+    end)
+
+    {:ok, project_path: tmp_dir}
+  end
+
+  defp set_req_test_from_context(_context) do
+    Req.Test.set_req_test_to_shared()
+    :ok
+  end
+
+  test "skips dispatch when a runner is already active" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+
+    {:ok, agent} =
+      Agent.start(fn -> :running end,
+        name: {:via, Registry, {CitadelAgent.RunnerRegistry, task_id}}
+      )
+
+    test_pid = self()
+
+    Req.Test.stub(:citadel_api, fn conn ->
+      send(test_pid, :claim_task_called)
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(204, "")
+    end)
+
+    {:ok, _} = start_supervised(CitadelAgent.Scheduler)
+
+    Process.sleep(100)
+
+    refute_received :claim_task_called
+
+    Agent.stop(agent)
+  end
+
+  test "claims task and spawns TaskRunner when no runner is active" do
+    task_id = "task-#{System.unique_integer([:positive])}"
+    human_id = "TEST-#{System.unique_integer([:positive])}"
+    run_id = "run-#{System.unique_integer([:positive])}"
+
+    Req.Test.stub(:citadel_api, fn conn ->
+      case {conn.method, conn.request_path} do
+        {"POST", "/api/agent/tasks/claim"} ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.send_resp(
+            200,
+            Jason.encode!(%{
+              "data" => %{
+                "task" => %{
+                  "id" => task_id,
+                  "human_id" => human_id,
+                  "title" => "Test task",
+                  "description" => "A test"
+                },
+                "agent_run" => %{"id" => run_id}
+              }
+            })
+          )
+
+        {"PATCH", "/api/agent/runs/" <> _} ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.send_resp(
+            200,
+            Jason.encode!(%{"data" => %{"id" => run_id, "status" => "failed"}})
+          )
+
+        _ ->
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => []}))
+      end
+    end)
+
+    {:ok, _} = start_supervised(CitadelAgent.Scheduler)
+
+    assert wait_until(fn ->
+             case Registry.lookup(CitadelAgent.RunnerRegistry, task_id) do
+               [{_pid, _}] -> true
+               [] -> false
+             end
+           end),
+           "TaskRunner was never spawned for #{task_id}"
+
+    wait_until(fn ->
+      Registry.lookup(CitadelAgent.RunnerRegistry, task_id) == []
+    end)
+  end
+
+  test "does not spawn runner when claim returns no tasks" do
+    test_pid = self()
+
+    Req.Test.stub(:citadel_api, fn conn ->
+      send(test_pid, :claim_called)
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(204, "")
+    end)
+
+    {:ok, _} = start_supervised(CitadelAgent.Scheduler)
+
+    assert_receive :claim_called, 2_000
+
+    Process.sleep(50)
+
+    refute CitadelAgent.Runners.has_active_runner?()
+  end
+
+  defp wait_until(fun, timeout \\ 5_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    if fun.() do
+      true
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        false
+      else
+        Process.sleep(10)
+        do_wait_until(fun, deadline)
+      end
+    end
+  end
+end

--- a/citadel_agent/test/citadel_agent/task_runner_test.exs
+++ b/citadel_agent/test/citadel_agent/task_runner_test.exs
@@ -1,0 +1,103 @@
+defmodule CitadelAgent.TaskRunnerTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: tmp_dir} do
+    System.cmd("git", ["init", "-b", "main"], cd: tmp_dir)
+    System.cmd("git", ["config", "user.email", "test@test.com"], cd: tmp_dir)
+    System.cmd("git", ["config", "user.name", "Test"], cd: tmp_dir)
+    File.write!(Path.join(tmp_dir, "README.md"), "# Test")
+    System.cmd("git", ["add", "."], cd: tmp_dir)
+    System.cmd("git", ["commit", "-m", "initial"], cd: tmp_dir)
+
+    registry = CitadelAgent.RunnerRegistry
+
+    case GenServer.whereis(registry) do
+      nil -> start_supervised!({Registry, keys: :unique, name: registry})
+      _pid -> :ok
+    end
+
+    original_url = CitadelAgent.config(:citadel_url)
+    Application.put_env(:citadel_agent, :citadel_url, "http://127.0.0.1:1")
+    on_exit(fn -> Application.put_env(:citadel_agent, :citadel_url, original_url) end)
+
+    task = %{
+      "id" => "task-#{System.unique_integer([:positive])}",
+      "human_id" => "TEST-#{System.unique_integer([:positive])}",
+      "title" => "Test task",
+      "description" => "A test task"
+    }
+
+    run = %{"id" => "run-#{System.unique_integer([:positive])}"}
+
+    {:ok, task: task, run: run, project_path: tmp_dir}
+  end
+
+  test "registers in RunnerRegistry on start", ctx do
+    {:ok, pid} = start_task_runner(ctx)
+
+    assert [{^pid, _}] = Registry.lookup(CitadelAgent.RunnerRegistry, ctx.task["id"])
+
+    wait_for_exit(pid)
+  end
+
+  test "deregisters from RunnerRegistry after execution completes", ctx do
+    {:ok, pid} = start_task_runner(ctx)
+    wait_for_exit(pid)
+
+    assert [] = Registry.lookup(CitadelAgent.RunnerRegistry, ctx.task["id"])
+  end
+
+  test "stops itself after execution", ctx do
+    {:ok, pid} = start_task_runner(ctx)
+    ref = Process.monitor(pid)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 10_000
+    refute Process.alive?(pid)
+  end
+
+  test "deregisters from RunnerRegistry after crash", ctx do
+    Process.flag(:trap_exit, true)
+    {:ok, pid} = start_task_runner(ctx)
+
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, :killed} -> :ok
+    after
+      5_000 -> raise "Process did not terminate"
+    end
+
+    Process.sleep(10)
+
+    assert [] = Registry.lookup(CitadelAgent.RunnerRegistry, ctx.task["id"])
+  end
+
+  test "does not allow duplicate runners for same task", ctx do
+    {:ok, pid} = start_task_runner(ctx)
+
+    assert {:error, {:already_started, ^pid}} = start_task_runner(ctx)
+
+    wait_for_exit(pid)
+  end
+
+  defp start_task_runner(ctx) do
+    CitadelAgent.TaskRunner.start_link(%{
+      task: ctx.task,
+      run: ctx.run,
+      project_path: ctx.project_path
+    })
+  end
+
+  defp wait_for_exit(pid) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    after
+      10_000 -> raise "TaskRunner did not exit in time"
+    end
+  end
+end

--- a/citadel_agent/test/citadel_agent/task_runner_test.exs
+++ b/citadel_agent/test/citadel_agent/task_runner_test.exs
@@ -83,6 +83,60 @@ defmodule CitadelAgent.TaskRunnerTest do
     wait_for_exit(pid)
   end
 
+  describe "terminate/2" do
+    setup ctx do
+      Req.Test.set_req_test_to_shared()
+
+      original_req_opts = Application.get_env(:citadel_agent, :client_req_options)
+      Application.put_env(:citadel_agent, :client_req_options, plug: {Req.Test, :citadel_api})
+
+      on_exit(fn ->
+        Req.Test.set_req_test_to_private()
+
+        if original_req_opts do
+          Application.put_env(:citadel_agent, :client_req_options, original_req_opts)
+        else
+          Application.delete_env(:citadel_agent, :client_req_options)
+        end
+      end)
+
+      ctx
+    end
+
+    test "calls update_run with failed status when active_run is set", ctx do
+      test_pid = self()
+      run_id = ctx.run["id"]
+
+      Req.Test.stub(:citadel_api, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:update_run, conn.request_path, Jason.decode!(body)})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{"data" => %{"id" => run_id}}))
+      end)
+
+      state = %{active_run: ctx.run, task: ctx.task, project_path: ctx.project_path}
+
+      CitadelAgent.TaskRunner.terminate(:test_crash, state)
+
+      assert_receive {:update_run, path, body}, 2_000
+      assert path == "/api/agent/runs/#{run_id}"
+      assert body["status"] == "failed"
+      assert body["error_message"] =~ "terminated"
+      assert body["completed_at"]
+    end
+
+    test "is a no-op for normal exit" do
+      assert :ok = CitadelAgent.TaskRunner.terminate(:normal, %{})
+    end
+
+    test "handles nil active_run on abnormal exit" do
+      state = %{active_run: nil, task: %{}, project_path: "/tmp"}
+      CitadelAgent.TaskRunner.terminate(:shutdown, state)
+    end
+  end
+
   defp start_task_runner(ctx) do
     CitadelAgent.TaskRunner.start_link(%{
       task: ctx.task,
@@ -99,5 +153,7 @@ defmodule CitadelAgent.TaskRunnerTest do
     after
       10_000 -> raise "TaskRunner did not exit in time"
     end
+
+    Process.sleep(10)
   end
 end

--- a/lib/citadel_web/channels/agent_channel.ex
+++ b/lib/citadel_web/channels/agent_channel.ex
@@ -14,8 +14,8 @@ defmodule CitadelWeb.AgentChannel do
     socket =
       socket
       |> assign(:agent_name, agent_name)
-      |> assign(:status, payload["status"] || "idle")
-      |> assign(:current_task_id, payload["current_task_id"])
+      |> assign(:initial_status, payload["status"] || "idle")
+      |> assign(:initial_task_id, payload["current_task_id"])
 
     workspace = Accounts.get_workspace_by_id!(socket.assigns.workspace_id, authorize?: false)
 
@@ -35,8 +35,8 @@ defmodule CitadelWeb.AgentChannel do
     topic = presence_topic(socket)
 
     AgentPresence.track(self(), topic, socket.assigns.agent_name, %{
-      status: socket.assigns.status,
-      current_task_id: socket.assigns.current_task_id,
+      status: socket.assigns.initial_status,
+      current_task_id: socket.assigns.initial_task_id,
       agent_name: socket.assigns.agent_name,
       joined_at: DateTime.utc_now() |> DateTime.to_iso8601()
     })

--- a/test/citadel_web/channels/agent_channel_test.exs
+++ b/test/citadel_web/channels/agent_channel_test.exs
@@ -61,8 +61,8 @@ defmodule CitadelWeb.AgentChannelTest do
           "agent_name" => agent_name
         })
 
-      assert socket.assigns.status == "idle"
-      assert socket.assigns.current_task_id == nil
+      assert socket.assigns.initial_status == "idle"
+      assert socket.assigns.initial_task_id == nil
     end
 
     test "uses status from join payload when provided", %{user: user, workspace: workspace} do
@@ -81,8 +81,8 @@ defmodule CitadelWeb.AgentChannelTest do
           "current_task_id" => task_id
         })
 
-      assert socket.assigns.status == "working"
-      assert socket.assigns.current_task_id == task_id
+      assert socket.assigns.initial_status == "working"
+      assert socket.assigns.initial_task_id == task_id
     end
   end
 


### PR DESCRIPTION
## Summary

- Extracts the task execution lifecycle out of `CitadelAgent.Worker` into a new, dedicated `CitadelAgent.TaskRunner` GenServer
- Each `TaskRunner` process owns exactly one task run: it creates the `AgentRun`, calls `Runner.execute/2`, reports results, and self-terminates
- Crash cleanup (`terminate/2`) marks the active run as failed, deregisters from `RunnerRegistry`, and pushes idle status over the WebSocket

## Motivation

`CitadelAgent.Worker` currently conflates two distinct responsibilities — polling for tasks and executing them. Mixing these in a single process means a crashed execution takes down the poller and makes crash handling ambiguous. Separating execution into a `TaskRunner` GenServer (started under a `DynamicSupervisor` with `restart: :temporary`) gives each run an isolated process with a clear lifecycle and clean crash semantics.

## Changes

- **New file**: `citadel_agent/lib/citadel_agent/task_runner.ex`
  - `start_link/1` — accepts `%{task: task, project_path: path}`
  - `init/1` — registers in `RunnerRegistry`, pushes `"working"` status, sends self `{:execute}`
  - `handle_info({:execute}, state)` — creates `AgentRun`, calls `Runner.execute/2`, reports results, transitions task to "In Review" on success, deregisters, pushes `"idle"`, stops with `:normal`
  - `terminate/2` — on crash, marks active run as `"failed"`, deregisters from registry, pushes `"idle"`
- **Moved from `Worker`**: `execute_task/2`, `create_run/1`, `mark_running/1`, `run_task/3`, `transition_task_to_in_review/1`, and the crash-handling `terminate/2` clause

## Dependencies

Requires `CitadelAgent.RunnerRegistry` to exist (P-174 subtask 1).

## Test plan

- [ ] `TaskRunner` registers in `RunnerRegistry` on init and deregisters on normal completion
- [ ] `"working"` status is pushed on start; `"idle"` is pushed on completion
- [ ] Successful execution transitions the task to "In Review"
- [ ] Crashing mid-execution (before `AgentRun` completes) triggers `terminate/2`: run marked `"failed"`, registry entry removed, `"idle"` pushed
- [ ] `TaskRunner` process exits after execution — does not remain alive