### PR TITLE
P-183: Set ancestors to "In Progress" on task claim

### DIFF
--- a/lib/citadel/tasks/changes/claim_next_task.ex
+++ b/lib/citadel/tasks/changes/claim_next_task.ex
@@ -2,6 +2,7 @@ defmodule Citadel.Tasks.Changes.ClaimNextTask do
   @moduledoc false
   use Ash.Resource.Change
 
+  require Ash.Query
   import Ecto.Query
 
   @impl true
@@ -30,6 +31,7 @@ defmodule Citadel.Tasks.Changes.ClaimNextTask do
     |> Ash.Changeset.force_change_attribute(:started_at, DateTime.utc_now())
     |> Ash.Changeset.after_action(fn _changeset, agent_run ->
       claim_work_item(work_item_id, agent_run.id, workspace_id)
+      transition_task_and_ancestors_to_in_progress(task_id, workspace_id)
       {:ok, agent_run}
     end)
   end
@@ -84,8 +86,6 @@ defmodule Citadel.Tasks.Changes.ClaimNextTask do
   end
 
   defp claim_work_item(work_item_id, agent_run_id, workspace_id) do
-    require Ash.Query
-
     Citadel.Tasks.AgentWorkItem
     |> Ash.Query.filter(id == ^work_item_id)
     |> Ash.read_one!(authorize?: false, tenant: workspace_id)
@@ -94,5 +94,41 @@ defmodule Citadel.Tasks.Changes.ClaimNextTask do
       tenant: workspace_id
     )
     |> Ash.update!()
+  end
+
+  defp transition_task_and_ancestors_to_in_progress(task_id, workspace_id) do
+    case get_in_progress_state() do
+      {:ok, in_progress_state} ->
+        transition_chain(task_id, in_progress_state.id, workspace_id)
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp transition_chain(nil, _in_progress_id, _workspace_id), do: :ok
+
+  defp transition_chain(task_id, in_progress_id, workspace_id) do
+    task =
+      Citadel.Tasks.Task
+      |> Ash.Query.filter(id == ^task_id)
+      |> Ash.read_one!(authorize?: false, tenant: workspace_id)
+
+    if task.task_state_id != in_progress_id do
+      task
+      |> Ash.Changeset.for_update(:update, %{task_state_id: in_progress_id},
+        authorize?: false,
+        tenant: workspace_id
+      )
+      |> Ash.update!()
+    end
+
+    transition_chain(task.parent_task_id, in_progress_id, workspace_id)
+  end
+
+  defp get_in_progress_state do
+    Citadel.Tasks.TaskState
+    |> Ash.Query.filter(name == "In Progress")
+    |> Ash.read_one(authorize?: false)
   end
 end

--- a/test/citadel/tasks/claim_next_task_test.exs
+++ b/test/citadel/tasks/claim_next_task_test.exs
@@ -316,4 +316,157 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
       assert agent_run.task_id == first.id
     end
   end
+
+  describe "state transitions on claim" do
+    defp reload_task(task, workspace_id) do
+      require Ash.Query
+
+      Citadel.Tasks.Task
+      |> Ash.Query.filter(id == ^task.id)
+      |> Ash.read_one!(authorize?: false, tenant: workspace_id)
+    end
+
+    test "claiming a task with no parent transitions only that task to In Progress", ctx do
+      task = create_eligible_task(ctx)
+
+      Tasks.claim_next_task!(
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      reloaded = reload_task(task, ctx.workspace.id)
+      assert reloaded.task_state_id == ctx.in_progress_state.id
+    end
+
+    test "claiming a task transitions its entire ancestor chain to In Progress", ctx do
+      grandparent =
+        Tasks.create_task!(
+          %{
+            title: "Grandparent #{System.unique_integer([:positive])}",
+            task_state_id: ctx.todo_state.id
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      parent =
+        Tasks.create_task!(
+          %{
+            title: "Parent #{System.unique_integer([:positive])}",
+            task_state_id: ctx.todo_state.id,
+            parent_task_id: grandparent.id
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      child =
+        Tasks.create_task!(
+          %{
+            title: "Child #{System.unique_integer([:positive])}",
+            task_state_id: ctx.todo_state.id,
+            parent_task_id: parent.id,
+            agent_eligible: true
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      Tasks.claim_next_task!(
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      assert reload_task(child, ctx.workspace.id).task_state_id == ctx.in_progress_state.id
+      assert reload_task(parent, ctx.workspace.id).task_state_id == ctx.in_progress_state.id
+      assert reload_task(grandparent, ctx.workspace.id).task_state_id == ctx.in_progress_state.id
+    end
+
+    test "ancestors already In Progress are not redundantly updated", ctx do
+      grandparent =
+        Tasks.create_task!(
+          %{
+            title: "GP Already IP #{System.unique_integer([:positive])}",
+            task_state_id: ctx.in_progress_state.id
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      parent =
+        Tasks.create_task!(
+          %{
+            title: "Parent Already IP #{System.unique_integer([:positive])}",
+            task_state_id: ctx.in_progress_state.id,
+            parent_task_id: grandparent.id
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      child =
+        Tasks.create_task!(
+          %{
+            title: "Child To Claim #{System.unique_integer([:positive])}",
+            task_state_id: ctx.todo_state.id,
+            parent_task_id: parent.id,
+            agent_eligible: true
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      grandparent_before = reload_task(grandparent, ctx.workspace.id)
+      parent_before = reload_task(parent, ctx.workspace.id)
+
+      Tasks.claim_next_task!(
+        actor: ctx.user,
+        tenant: ctx.workspace.id
+      )
+
+      child_after = reload_task(child, ctx.workspace.id)
+      parent_after = reload_task(parent, ctx.workspace.id)
+      grandparent_after = reload_task(grandparent, ctx.workspace.id)
+
+      assert child_after.task_state_id == ctx.in_progress_state.id
+      assert parent_after.task_state_id == ctx.in_progress_state.id
+      assert grandparent_after.task_state_id == ctx.in_progress_state.id
+
+      assert grandparent_after.updated_at == grandparent_before.updated_at
+      assert parent_after.updated_at == parent_before.updated_at
+    end
+
+    test "claim failure does not change any task states", ctx do
+      parent =
+        Tasks.create_task!(
+          %{
+            title: "Parent No Claim #{System.unique_integer([:positive])}",
+            task_state_id: ctx.todo_state.id
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      child =
+        Tasks.create_task!(
+          %{
+            title: "Child Not Eligible #{System.unique_integer([:positive])}",
+            task_state_id: ctx.todo_state.id,
+            parent_task_id: parent.id,
+            agent_eligible: false
+          },
+          actor: ctx.user,
+          tenant: ctx.workspace.id
+        )
+
+      assert {:error, _} =
+               Tasks.claim_next_task(
+                 actor: ctx.user,
+                 tenant: ctx.workspace.id
+               )
+
+      assert reload_task(parent, ctx.workspace.id).task_state_id == ctx.todo_state.id
+      assert reload_task(child, ctx.workspace.id).task_state_id == ctx.todo_state.id
+    end
+  end
 end

--- a/test/citadel/tasks/claim_next_task_test.exs
+++ b/test/citadel/tasks/claim_next_task_test.exs
@@ -34,12 +34,24 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
           existing
       end
 
+    in_progress_state =
+      case Citadel.Tasks.TaskState
+           |> Ash.Query.filter(name == "In Progress")
+           |> Ash.read_one(authorize?: false) do
+        {:ok, nil} ->
+          Tasks.create_task_state!(%{name: "In Progress", order: 2, is_complete: false})
+
+        {:ok, existing} ->
+          existing
+      end
+
     {:ok,
      user: user,
      workspace: workspace,
      todo_state: todo_state,
      done_state: done_state,
-     in_review_state: in_review_state}
+     in_review_state: in_review_state,
+     in_progress_state: in_progress_state}
   end
 
   defp create_eligible_task(ctx, opts \\ []) do
@@ -72,7 +84,7 @@ defmodule Citadel.Tasks.ClaimNextTaskTest do
       assert agent_run.workspace_id == ctx.workspace.id
       assert agent_run.user_id == ctx.user.id
       assert agent_run.task.id == task.id
-      assert agent_run.task.task_state.id == ctx.todo_state.id
+      assert agent_run.task.task_state.id == ctx.in_progress_state.id
     end
 
     test "returns error when no eligible tasks exist", ctx do


### PR DESCRIPTION
## Summary

Extends `Citadel.Tasks.Changes.ClaimNextTask` so that a successful claim also transitions the claimed task and all of its ancestors to the "In Progress" state.

## Changes

- Added `transition_task_and_ancestors_to_in_progress/2` helper in `ClaimNextTask` that walks the `parent_task_id` chain from the claimed task up to the root, setting each task's `task_state_id` to the "In Progress" state
- Skips tasks already in the "In Progress" state to avoid redundant writes and PubSub broadcasts
- All updates go through the Ash `:update` action (not raw Ecto) so existing change logic and PubSub publishes fire correctly
- Transition is invoked inside the existing `after_action` callback in `apply_claim/4`, after `claim_work_item/3` succeeds — no changes to the claim path itself
- Follows the same `authorize?: false` + `tenant: workspace_id` pattern used in `RequestChanges`
- If the "In Progress" `TaskState` cannot be found, the helper returns `:ok` without crashing the claim

## Behavior

- Claim flow is unchanged: `AgentRun` status → `:running`, `started_at` set, `AgentWorkItem` claimed
- If no tasks are available for claim, no state transitions occur
- A task chain like grandparent → parent → child (all in "To Do") will have all three moved to "In Progress" after the child is claimed