### PR TITLE
fix(docker): copy npm manifests before mix assets.setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN mkdir config
 COPY config/config.exs config/${MIX_ENV}.exs config/
 RUN mix deps.compile
 
+# copy npm manifests before assets.setup so `npm install --prefix assets` works
+COPY assets/package.json assets/package-lock.json assets/
 RUN mix assets.setup
 
 COPY priv priv
@@ -61,9 +63,6 @@ COPY lib lib
 RUN mix compile
 
 COPY assets assets
-
-# install npm dependencies
-RUN npm ci --prefix assets
 
 # compile assets
 RUN mix assets.deploy


### PR DESCRIPTION
## Summary
- Fly deploys have been failing at `RUN mix assets.setup` with `ENOENT: no such file or directory, open '/app/assets/package.json'`.
- Root cause: commit `fdbeb77` (Svelte build pipeline) added `cmd npm install --prefix assets` to the `assets.setup` mix alias, but the Dockerfile ran `mix assets.setup` before `COPY assets assets`.
- Fix: copy `assets/package.json` + `assets/package-lock.json` before `mix assets.setup`, and remove the now-redundant `npm ci --prefix assets` step that followed the full assets copy.

## Test plan
- [x] Verified locally with `docker build -t citadel-test:dockerfile-fix .` — build completes end-to-end, `mix assets.setup` now succeeds.
- [ ] CI pipeline passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)