### PR TITLE
fix(observability): stop double-parsing OTLP headers

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -144,21 +144,11 @@ if config_env() == :prod do
     before_send: {Citadel.Observability.SentryFilter, :before_send}
 
   # ── OpenTelemetry → Grafana Cloud Tempo (OTLP) ─────────
-  if otlp_endpoint = System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT") do
-    otlp_headers =
-      System.get_env("OTEL_EXPORTER_OTLP_HEADERS", "")
-      |> String.split(",", trim: true)
-      |> Enum.map(fn kv ->
-        [k, v] = String.split(kv, "=", parts: 2)
-        {String.trim(k), String.trim(v)}
-      end)
-
+  # Headers come from OTEL_EXPORTER_OTLP_HEADERS and are parsed by
+  # opentelemetry_exporter directly per the OTel spec — don't re-parse here.
+  if System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT") do
     config :opentelemetry, traces_exporter: :otlp
-
-    config :opentelemetry_exporter,
-      otlp_protocol: :http_protobuf,
-      otlp_endpoint: otlp_endpoint,
-      otlp_headers: otlp_headers
+    config :opentelemetry_exporter, otlp_protocol: :http_protobuf
   end
 
   # ── PromEx → Grafana Cloud Prometheus remote_write ─────

--- a/lib/citadel/application.ex
+++ b/lib/citadel/application.ex
@@ -56,5 +56,28 @@ defmodule Citadel.Application do
     :logger.add_handler(:sentry_handler, Sentry.LoggerHandler, %{
       config: %{metadata: [:request_id, :trace_id, :span_id]}
     })
+
+    log_otlp_diagnostics()
+  end
+
+  defp log_otlp_diagnostics do
+    endpoint = System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT")
+    raw_headers = System.get_env("OTEL_EXPORTER_OTLP_HEADERS", "")
+
+    header_names =
+      raw_headers
+      |> String.split(",", trim: true)
+      |> Enum.map(fn kv ->
+        case String.split(kv, "=", parts: 2) do
+          [k, _v] -> String.trim(k)
+          _ -> "<unparseable>"
+        end
+      end)
+
+    require Logger
+
+    Logger.info(
+      "otlp diagnostics: endpoint=#{inspect(endpoint)} header_names=#{inspect(header_names)} header_count=#{length(header_names)}"
+    )
   end
 end


### PR DESCRIPTION
## Summary

Production is logging `401 authentication error: no credentials provided` from Grafana Cloud's OTLP gateway, despite `OTEL_EXPORTER_OTLP_HEADERS` being set correctly in Fly secrets.

**Root cause:** `opentelemetry_exporter` reads `OTEL_EXPORTER_OTLP_HEADERS` from the OS environment directly per the OTel spec, and in \`otel_configuration:merge_list_with_environment/3\` **OS env takes precedence over Application env**. Our manual parsing in \`config/runtime.exs\` was dead code — the library's own parser is what actually runs. When the env-var value is malformed, that parser silently returns an empty list (no header added), which is what produces the 401.

## Changes

- **`config/runtime.exs`** — remove the duplicate header-parsing pipeline. The exporter still needs to know the protocol is `http_protobuf` and that the `otlp` exporter is enabled, but headers are intentionally not set from runtime — they come from the env var through the library's own spec-compliant parser.
- **`lib/citadel/application.ex`** — add a one-line boot-time diagnostic log showing the OTLP endpoint (full value) and the **names** of headers parsed from the env var (values never logged). If this logs `header_count=0` after deploy, the env var value is malformed in the expected way.

## Why this fix alone might not be enough

If the header env var itself is malformed (e.g. surrounding quotes, extra whitespace, missing `=`, or a format other than `authorization=Basic <base64>`), the library's parser will still return `[]` and the 401 will persist. The diagnostic log is there so we can see that post-deploy and correct the secret.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [ ] After deploy, check Fly logs for the `otlp diagnostics:` line — confirm `header_count=1` and `header_names=["authorization"]`
- [ ] After deploy, check Grafana Cloud Explore → Tempo → traces for `service.name=citadel` start appearing
- [ ] If `header_count=0` still shows up, re-set `OTEL_EXPORTER_OTLP_HEADERS` carefully (format: `authorization=Basic <base64>`, no surrounding quotes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)