### PR TITLE
chore(observability): drop deprecated Sentry :included_environments

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,11 +136,12 @@ end
 
 if config_env() == :prod do
   # ── Sentry ─────────────────────────────────────────────
+  # :included_environments is deprecated in sentry 10.x — presence of :dsn
+  # is what enables event shipping, and :dsn is only set here (prod block).
   config :sentry,
     dsn: System.get_env("SENTRY_DSN"),
     environment_name: System.get_env("SENTRY_ENV", "production"),
     release: to_string(Application.spec(:citadel, :vsn)),
-    included_environments: [:prod],
     before_send: {Citadel.Observability.SentryFilter, :before_send}
 
   # ── OpenTelemetry → Grafana Cloud Tempo (OTLP) ─────────


### PR DESCRIPTION
## Summary

Every boot logs a deprecation warning with a stack trace:

\`\`\`
warning: :included_environments option is deprecated. Use :dsn to control whether to send events to Sentry.
  (nimble_options 1.1.1) lib/nimble_options.ex:575: NimbleOptions.validate_value/3
  ...
\`\`\`

In \`sentry\` 10.x, presence of \`:dsn\` is what enables event shipping. Since we only set \`:dsn\` inside the \`config_env() == :prod\` block in \`runtime.exs\`, removing \`:included_environments: [:prod]\` is behavior-preserving — events still only ship in prod.

## Test plan

- [x] \`mix compile --warnings-as-errors\` clean
- [ ] After deploy, confirm the deprecation warning is gone from fly logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)