### PR TITLE
perf(dashboard): fix N+1 by preloading blocked?/blocking_count

### DIFF
--- a/lib/citadel_web/live/components/tasks_list_component.ex
+++ b/lib/citadel_web/live/components/tasks_list_component.ex
@@ -78,7 +78,7 @@ defmodule CitadelWeb.Components.TasksListComponent do
     {:ok, socket}
   end
 
-  @required_loads [:task_state, :assignees, :overdue?]
+  @required_loads [:task_state, :assignees, :overdue?, :blocked?, :blocking_count]
 
   defp ensure_loaded(%{__struct__: Citadel.Tasks.Task} = task, socket) do
     loads_needed =
@@ -110,7 +110,7 @@ defmodule CitadelWeb.Components.TasksListComponent do
       Tasks.get_task!(task_id,
         actor: socket.assigns.current_user,
         tenant: socket.assigns.current_workspace.id,
-        load: [:task_state, :assignees, :overdue?]
+        load: @required_loads
       )
 
     old_state_id = task.task_state_id
@@ -123,9 +123,7 @@ defmodule CitadelWeb.Components.TasksListComponent do
       )
 
     updated_task =
-      Ash.load!(updated_task, [:task_state, :assignees, :overdue?],
-        tenant: socket.assigns.current_workspace.id
-      )
+      Ash.load!(updated_task, @required_loads, tenant: socket.assigns.current_workspace.id)
 
     # Update streams - delete from old state, insert into new state
     old_count = Map.get(socket.assigns.tasks_by_state_count, old_state_id, 1)
@@ -163,7 +161,7 @@ defmodule CitadelWeb.Components.TasksListComponent do
       Tasks.list_top_level_tasks!(
         actor: socket.assigns.current_user,
         tenant: socket.assigns.current_workspace.id,
-        load: [:task_state, :assignees, :overdue?]
+        load: @required_loads
       )
 
     assign(socket, :tasks, tasks)


### PR DESCRIPTION
## Summary
- Dashboard `/dashboard` trace showed ~100+ spans (8.59s) because `TaskStateDropdown.update_many/1` lazy-loads `[:blocked?, :blocking_count]` per task when they come in `NotLoaded`. Each load cascades into a `dependencies` + dependency `task_state` query — the repeating `tasks` / `task_states` spans in the trace.
- Added `:blocked?` and `:blocking_count` to the initial `list_top_level_tasks!` load (and the drag-drop re-load) in `TasksListComponent`. Ash batches the dependency/task_state fetches across all tasks in one pass, and the child component's fast path short-circuits — no more per-task queries.
- Mirrors the existing pattern in `CitadelWeb.TaskLive.Show` which already preloads these fields.

## Test plan
- [x] `mix ck` (format, compile, credo, sobelow) clean
- [x] `mix test test/citadel_web/live/dashboard_live/` — 11 passing
- [x] `mix test test/citadel_web/live/task_live/` — 76 passing
- [ ] Hit `/dashboard` in dev, confirm Grafana trace shows single bulk query for preloaded calcs (no per-task fan-out)
- [ ] Open a blocked task's state dropdown — "Incomplete Dependencies" modal still appears
- [ ] Drag-drop a task across state columns — reloaded task renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)