### PR TITLE
feat(observability): capture all error-level logs in Sentry

### DIFF
--- a/lib/citadel/application.ex
+++ b/lib/citadel/application.ex
@@ -54,7 +54,11 @@ defmodule Citadel.Application do
     OpentelemetryLoggerMetadata.setup()
 
     :logger.add_handler(:sentry_handler, Sentry.LoggerHandler, %{
-      config: %{metadata: [:request_id, :trace_id, :span_id]}
+      config: %{
+        metadata: [:request_id, :trace_id, :span_id],
+        capture_log_messages: true,
+        level: :error
+      }
     })
 
     log_otlp_diagnostics()


### PR DESCRIPTION
## Summary

Before this change, \`Sentry.LoggerHandler\` only captured:

- Unhandled BEAM crashes (via \`:logger\`'s built-in SASL crash reports)
- \`Logger.error/warning\` calls that include \`exception:\` metadata (e.g. from \`try/rescue\` blocks that explicitly pass the exception)

So plain \`Logger.error(\"payment failed for user \#{id}\")\` calls — the most common form — silently never reached Sentry.

With \`capture_log_messages: true\` and \`level: :error\`:

- Every \`:error\` (or higher) log line becomes a Sentry event
- Independent of how the log was emitted
- \`:error\` floor prevents \`:warning\` floods from eating the 5k/month free quota

## Quota math

At 5k events/month, Sentry lets you afford ~165 error-level log lines per day before you pay. If production outputs more errors than that per day, there are bigger problems to fix than observability costs.

## Test plan

- [x] \`mix compile --warnings-as-errors\` clean
- [ ] After deploy, run an IEx session and call \`Logger.error(\"test-event\")\` — should appear in Sentry within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)