### PR TITLE
perf(task-show): load task data async and eliminate dependencies N+1

### DIFF
--- a/lib/citadel/tasks/task.ex
+++ b/lib/citadel/tasks/task.ex
@@ -332,6 +332,7 @@ defmodule Citadel.Tasks.Task do
     has_many :sub_tasks, __MODULE__, destination_attribute: :parent_task_id
     has_many :agent_runs, Citadel.Tasks.AgentRun
     has_many :work_items, Citadel.Tasks.AgentWorkItem
+    has_many :dependency_records, Citadel.Tasks.TaskDependency, destination_attribute: :task_id
 
     many_to_many :assignees, Citadel.Accounts.User do
       through Citadel.Tasks.TaskAssignment

--- a/lib/citadel_web/live/components/task_activity_section.ex
+++ b/lib/citadel_web/live/components/task_activity_section.ex
@@ -17,19 +17,13 @@ defmodule CitadelWeb.Components.TaskActivitySection do
   end
 
   def update(assigns, socket) do
+    {activities, assigns} = Map.pop(assigns, :activities, [])
     socket = assign(socket, assigns)
 
     socket =
       if socket.assigns[:activities_loaded] do
         socket
       else
-        activities =
-          Tasks.list_task_activities!(assigns.task.id,
-            actor: assigns.current_user,
-            tenant: assigns.current_workspace.id,
-            load: [:user, :agent_run]
-          )
-
         socket
         |> stream(:activities, activities)
         |> assign(:activities_loaded, true)

--- a/lib/citadel_web/live/components/task_dependencies.ex
+++ b/lib/citadel_web/live/components/task_dependencies.ex
@@ -9,10 +9,16 @@ defmodule CitadelWeb.Components.TaskDependencies do
     dependencies_loaded = not match?(%Ash.NotLoaded{}, assigns.task.dependencies)
     dependents_loaded = not match?(%Ash.NotLoaded{}, assigns.task.dependents)
 
+    dep_records =
+      case assigns.task.dependency_records do
+        %Ash.NotLoaded{} -> []
+        records -> records
+      end
+
     {:ok,
      socket
      |> assign(assigns)
-     |> assign_new(:task_dependencies, fn -> [] end)
+     |> assign(:dep_map, Map.new(dep_records, fn r -> {r.depends_on_task_id, r.id} end))
      |> assign(:dependencies_loaded, dependencies_loaded)
      |> assign(:dependents_loaded, dependents_loaded)}
   end
@@ -45,9 +51,6 @@ defmodule CitadelWeb.Components.TaskDependencies do
               <%= if Enum.empty?(@task.dependencies) do %>
                 <p class="text-base-content/50 italic text-sm">None</p>
               <% else %>
-                <% # Create a map from depends_on_task_id to TaskDependency ID
-                dep_map =
-                  Map.new(@task_dependencies, fn td -> {td.depends_on_task_id, td.id} end) %>
                 <div class="space-y-2">
                   <%= for dep <- @task.dependencies do %>
                     <div class="flex items-center justify-between p-2 bg-base-100 rounded-lg border border-base-300">
@@ -62,7 +65,7 @@ defmodule CitadelWeb.Components.TaskDependencies do
                       <%= if @can_edit do %>
                         <button
                           phx-click="remove-dependency"
-                          phx-value-id={Map.get(dep_map, dep.id)}
+                          phx-value-id={Map.get(@dep_map, dep.id)}
                           class="btn btn-ghost btn-xs text-error"
                           title="Remove dependency"
                         >

--- a/lib/citadel_web/live/task_live/show.ex
+++ b/lib/citadel_web/live/task_live/show.ex
@@ -14,51 +14,50 @@ defmodule CitadelWeb.TaskLive.Show do
 
   alias CitadelWeb.Components.TaskActivitySection
 
+  @task_load [
+    :task_state,
+    :user,
+    :ancestors,
+    :assignees,
+    :overdue?,
+    :blocked?,
+    :blocking_count,
+    :project,
+    :execution_status,
+    dependency_records: [],
+    dependencies: [:task_state],
+    dependents: [:task_state]
+  ]
+
+  @sub_tasks_load [:task_state, :assignees, :overdue?]
+
   def mount(%{"id" => id}, _session, socket) do
-    task =
-      Tasks.get_task_by_human_id!(id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id,
-        load: [
-          :task_state,
-          :user,
-          :parent_task,
-          :ancestors,
-          :assignees,
-          :overdue?,
-          :blocked?,
-          :blocking_count,
-          :project,
-          :execution_status,
-          :active_agent_run,
-          dependencies: [:task_state],
-          dependents: [:task_state]
-        ]
-      )
+    user = socket.assigns.current_user
+    workspace_id = socket.assigns.current_workspace.id
 
-    sub_tasks =
-      Tasks.list_sub_tasks!(task.id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id,
-        load: [:task_state, :assignees, :overdue?]
-      )
+    socket =
+      socket
+      |> assign(:human_id, id)
+      |> assign(:task, nil)
+      |> assign(:sub_tasks, [])
+      |> assign(:sub_tasks_count, 0)
+      |> assign(:activities, [])
+      |> assign(:can_edit, false)
+      |> assign(:can_delete, false)
+      |> assign(:show_sub_task_form, false)
+      |> assign(:confirm_delete, false)
+      |> assign(:cancel_run_id, nil)
+      |> assign(:load_error, nil)
+      |> start_async(:load_task, fn -> load_task_data(id, user, workspace_id) end)
 
-    task_dependencies =
-      Tasks.list_task_dependencies!(task.id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id
-      )
+    {:ok, socket}
+  end
 
-    can_edit = Ash.can?({task, :update}, socket.assigns.current_user)
-    can_delete = Ash.can?({task, :destroy}, socket.assigns.current_user)
+  def handle_async(:load_task, {:ok, {:ok, data}}, socket) do
+    %{task: task, sub_tasks: sub_tasks, activities: activities} = data
 
     if connected?(socket) do
-      CitadelWeb.Endpoint.subscribe("tasks:task:#{task.id}")
-      CitadelWeb.Endpoint.subscribe("tasks:task_children:#{task.id}")
-      CitadelWeb.Endpoint.subscribe("tasks:task_dependencies:#{task.id}")
-      CitadelWeb.Endpoint.subscribe("tasks:task_dependents:#{task.id}")
-      CitadelWeb.Endpoint.subscribe("tasks:task_activities:#{task.id}")
-      CitadelWeb.Endpoint.subscribe("tasks:agent_runs:#{task.id}")
+      subscribe_to_task_topics(task.id)
     end
 
     socket =
@@ -66,14 +65,60 @@ defmodule CitadelWeb.TaskLive.Show do
       |> assign(:task, task)
       |> assign(:sub_tasks, sub_tasks)
       |> assign(:sub_tasks_count, length(sub_tasks))
-      |> assign(:task_dependencies, task_dependencies)
-      |> assign(:can_edit, can_edit)
-      |> assign(:can_delete, can_delete)
-      |> assign(:show_sub_task_form, false)
-      |> assign(:confirm_delete, false)
-      |> assign(:cancel_run_id, nil)
+      |> assign(:activities, activities)
+      |> assign(:can_edit, data.can_edit)
+      |> assign(:can_delete, data.can_delete)
 
-    {:ok, socket}
+    {:noreply, socket}
+  end
+
+  def handle_async(:load_task, {:ok, {:error, reason}}, socket) do
+    {:noreply, assign(socket, :load_error, reason)}
+  end
+
+  def handle_async(:load_task, {:exit, reason}, socket) do
+    {:noreply, assign(socket, :load_error, reason)}
+  end
+
+  defp load_task_data(human_id, user, workspace_id) do
+    opts = [actor: user, tenant: workspace_id]
+
+    with {:ok, task} <-
+           Tasks.get_task_by_human_id(human_id, Keyword.put(opts, :load, @task_load)) do
+      [sub_tasks, activities] =
+        [
+          fn ->
+            Tasks.list_sub_tasks!(task.id, Keyword.put(opts, :load, @sub_tasks_load))
+          end,
+          fn ->
+            Tasks.list_task_activities!(task.id, Keyword.put(opts, :load, [:user, :agent_run]))
+          end
+        ]
+        |> Task.async_stream(fn fun -> fun.() end,
+          ordered: true,
+          max_concurrency: 2,
+          timeout: 30_000
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      {:ok,
+       %{
+         task: task,
+         sub_tasks: sub_tasks,
+         activities: activities,
+         can_edit: Ash.can?({task, :update}, user),
+         can_delete: Ash.can?({task, :destroy}, user)
+       }}
+    end
+  end
+
+  defp subscribe_to_task_topics(task_id) do
+    CitadelWeb.Endpoint.subscribe("tasks:task:#{task_id}")
+    CitadelWeb.Endpoint.subscribe("tasks:task_children:#{task_id}")
+    CitadelWeb.Endpoint.subscribe("tasks:task_dependencies:#{task_id}")
+    CitadelWeb.Endpoint.subscribe("tasks:task_dependents:#{task_id}")
+    CitadelWeb.Endpoint.subscribe("tasks:task_activities:#{task_id}")
+    CitadelWeb.Endpoint.subscribe("tasks:agent_runs:#{task_id}")
   end
 
   def handle_event("new-sub-task", _params, socket) do
@@ -95,12 +140,11 @@ defmodule CitadelWeb.TaskLive.Show do
              tenant: socket.assigns.current_workspace.id
            ) do
         {:ok, _dependency} ->
-          {task, task_dependencies} = reload_task_with_dependencies(socket)
+          task = reload_task(socket)
 
           {:noreply,
            socket
            |> assign(:task, task)
-           |> assign(:task_dependencies, task_dependencies)
            |> put_flash(:info, "Dependency added successfully")}
 
         {:error, error} ->
@@ -116,12 +160,11 @@ defmodule CitadelWeb.TaskLive.Show do
            tenant: socket.assigns.current_workspace.id
          ) do
       :ok ->
-        {task, task_dependencies} = reload_task_with_dependencies(socket)
+        task = reload_task(socket)
 
         {:noreply,
          socket
          |> assign(:task, task)
-         |> assign(:task_dependencies, task_dependencies)
          |> put_flash(:info, "Dependency removed successfully")}
 
       {:error, _} ->
@@ -138,21 +181,7 @@ defmodule CitadelWeb.TaskLive.Show do
          ) do
       {:ok, task} ->
         task =
-          Ash.load!(
-            task,
-            [
-              :task_state,
-              :user,
-              :parent_task,
-              :ancestors,
-              :assignees,
-              :overdue?,
-              :project,
-              :execution_status,
-              :active_agent_run
-            ],
-            tenant: socket.assigns.current_workspace.id
-          )
+          Ash.load!(task, @task_load, tenant: socket.assigns.current_workspace.id)
 
         {:noreply, assign(socket, :task, task)}
 
@@ -171,12 +200,12 @@ defmodule CitadelWeb.TaskLive.Show do
 
   def handle_event("delete", _params, socket) do
     task = socket.assigns.task
-    parent_task = task.parent_task
+    parent = List.last(task.ancestors || [])
 
     case Tasks.destroy_task(task, actor: socket.assigns.current_user) do
       :ok ->
         redirect_path =
-          if parent_task, do: ~p"/tasks/#{parent_task.human_id}", else: ~p"/dashboard"
+          if parent, do: ~p"/tasks/#{parent.human_id}", else: ~p"/dashboard"
 
         {:noreply,
          socket
@@ -230,19 +259,7 @@ defmodule CitadelWeb.TaskLive.Show do
            tenant: socket.assigns.current_workspace.id
          ) do
       {:ok, task} ->
-        task =
-          Ash.load!(
-            task,
-            [
-              :task_state,
-              :user,
-              :parent_task,
-              :ancestors,
-              :assignees,
-              :overdue?
-            ],
-            tenant: socket.assigns.current_workspace.id
-          )
+        task = Ash.load!(task, @task_load, tenant: socket.assigns.current_workspace.id)
 
         {:noreply, assign(socket, :task, task)}
 
@@ -263,21 +280,7 @@ defmodule CitadelWeb.TaskLive.Show do
            ) do
         {:ok, task} ->
           task =
-            Ash.load!(
-              task,
-              [
-                :task_state,
-                :user,
-                :parent_task,
-                :ancestors,
-                :assignees,
-                :overdue?,
-                :project,
-                :execution_status,
-                :active_agent_run
-              ],
-              tenant: socket.assigns.current_workspace.id
-            )
+            Ash.load!(task, @task_load, tenant: socket.assigns.current_workspace.id)
 
           {:noreply, assign(socket, :task, task)}
 
@@ -299,21 +302,7 @@ defmodule CitadelWeb.TaskLive.Show do
            ) do
         {:ok, task} ->
           task =
-            Ash.load!(
-              task,
-              [
-                :task_state,
-                :user,
-                :parent_task,
-                :ancestors,
-                :assignees,
-                :overdue?,
-                :project,
-                :execution_status,
-                :active_agent_run
-              ],
-              tenant: socket.assigns.current_workspace.id
-            )
+            Ash.load!(task, @task_load, tenant: socket.assigns.current_workspace.id)
 
           {:noreply, assign(socket, :task, task)}
 
@@ -324,12 +313,7 @@ defmodule CitadelWeb.TaskLive.Show do
   end
 
   def handle_info({:task_created, _sub_task}, socket) do
-    sub_tasks =
-      Tasks.list_sub_tasks!(socket.assigns.task.id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id,
-        load: [:task_state, :assignees, :overdue?]
-      )
+    sub_tasks = list_sub_tasks(socket)
 
     send_update(CitadelWeb.Components.TasksListComponent,
       id: "sub-tasks-#{socket.assigns.task.id}",
@@ -357,19 +341,7 @@ defmodule CitadelWeb.TaskLive.Show do
            tenant: socket.assigns.current_workspace.id
          ) do
       {:ok, task} ->
-        task =
-          Ash.load!(
-            task,
-            [
-              :task_state,
-              :user,
-              :parent_task,
-              :ancestors,
-              :assignees,
-              :overdue?
-            ],
-            tenant: socket.assigns.current_workspace.id
-          )
+        task = Ash.load!(task, @task_load, tenant: socket.assigns.current_workspace.id)
 
         {:noreply, assign(socket, :task, task)}
 
@@ -382,43 +354,24 @@ defmodule CitadelWeb.TaskLive.Show do
         %Phoenix.Socket.Broadcast{topic: "tasks:task_dependencies:" <> _task_id},
         socket
       ) do
-    {task, task_dependencies} = reload_task_with_dependencies(socket)
-    {:noreply, socket |> assign(:task, task) |> assign(:task_dependencies, task_dependencies)}
+    {:noreply, assign(socket, :task, reload_task(socket))}
   end
 
   def handle_info(
         %Phoenix.Socket.Broadcast{topic: "tasks:task_dependents:" <> _task_id},
         socket
       ) do
-    {task, task_dependencies} = reload_task_with_dependencies(socket)
-    {:noreply, socket |> assign(:task, task) |> assign(:task_dependencies, task_dependencies)}
+    {:noreply, assign(socket, :task, reload_task(socket))}
   end
 
   def handle_info({:task_state_changed, _task}, socket) do
     task =
-      Ash.load!(
-        socket.assigns.task,
-        [
-          :task_state,
-          :user,
-          :parent_task,
-          :ancestors,
-          :assignees,
-          :overdue?,
-          :project,
-          :execution_status,
-          :active_agent_run
-        ],
+      Ash.load!(socket.assigns.task, @task_load,
         actor: socket.assigns.current_user,
         tenant: socket.assigns.current_workspace.id
       )
 
-    sub_tasks =
-      Tasks.list_sub_tasks!(task.id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id,
-        load: [:task_state, :assignees, :overdue?]
-      )
+    sub_tasks = list_sub_tasks(socket)
 
     send_update(CitadelWeb.Components.TasksListComponent,
       id: "sub-tasks-#{task.id}",
@@ -435,12 +388,7 @@ defmodule CitadelWeb.TaskLive.Show do
   end
 
   def handle_info({:tasks_list_task_moved, _component_id}, socket) do
-    sub_tasks =
-      Tasks.list_sub_tasks!(socket.assigns.task.id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id,
-        load: [:task_state, :assignees, :overdue?]
-      )
+    sub_tasks = list_sub_tasks(socket)
 
     send_update(CitadelWeb.Components.TasksListComponent,
       id: "sub-tasks-#{socket.assigns.task.id}",
@@ -464,17 +412,7 @@ defmodule CitadelWeb.TaskLive.Show do
         Tasks.get_task!(task_id,
           actor: socket.assigns.current_user,
           tenant: socket.assigns.current_workspace.id,
-          load: [
-            :task_state,
-            :user,
-            :parent_task,
-            :ancestors,
-            :assignees,
-            :overdue?,
-            :project,
-            :execution_status,
-            :active_agent_run
-          ]
+          load: @task_load
         )
 
       {:noreply, assign(socket, :task, task)}
@@ -522,35 +460,20 @@ defmodule CitadelWeb.TaskLive.Show do
     {:noreply, assign(socket, :cancel_run_id, run_id)}
   end
 
-  defp reload_task_with_dependencies(socket) do
-    task =
-      Tasks.get_task!(socket.assigns.task.id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id,
-        load: [
-          :task_state,
-          :user,
-          :parent_task,
-          :ancestors,
-          :assignees,
-          :overdue?,
-          :blocked?,
-          :blocking_count,
-          :project,
-          :execution_status,
-          :active_agent_run,
-          dependencies: [:task_state],
-          dependents: [:task_state]
-        ]
-      )
+  defp reload_task(socket) do
+    Tasks.get_task!(socket.assigns.task.id,
+      actor: socket.assigns.current_user,
+      tenant: socket.assigns.current_workspace.id,
+      load: @task_load
+    )
+  end
 
-    task_dependencies =
-      Tasks.list_task_dependencies!(task.id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id
-      )
-
-    {task, task_dependencies}
+  defp list_sub_tasks(socket) do
+    Tasks.list_sub_tasks!(socket.assigns.task.id,
+      actor: socket.assigns.current_user,
+      tenant: socket.assigns.current_workspace.id,
+      load: @sub_tasks_load
+    )
   end
 
   defp format_dependency_error(error, human_id) do
@@ -576,12 +499,7 @@ defmodule CitadelWeb.TaskLive.Show do
   end
 
   defp handle_sub_task_broadcast(_sub_task, socket) do
-    sub_tasks =
-      Tasks.list_sub_tasks!(socket.assigns.task.id,
-        actor: socket.assigns.current_user,
-        tenant: socket.assigns.current_workspace.id,
-        load: [:task_state, :assignees, :overdue?]
-      )
+    sub_tasks = list_sub_tasks(socket)
 
     maybe_notify_sub_tasks_updated(sub_tasks, socket)
 
@@ -649,284 +567,29 @@ defmodule CitadelWeb.TaskLive.Show do
       agents={@agents}
     >
       <div class="relative h-full p-4 bg-base-200 border border-base-300">
-        <div class="h-full overflow-auto ">
-          <div class="breadcrumbs text-sm mb-4">
-            <ul>
-              <li><.link navigate={~p"/dashboard"}>Tasks</.link></li>
-              <li :for={ancestor <- @task.ancestors}>
-                <.link navigate={~p"/tasks/#{ancestor.human_id}"}>{ancestor.human_id}</.link>
-              </li>
-              <li><span>{@task.human_id}</span></li>
-            </ul>
-          </div>
-
-          <div class="flex items-start justify-between pr-3">
-            <div class="flex items-center gap-3 flex-1">
-              <%= if @can_edit do %>
-                <.live_component
-                  module={CitadelWeb.Components.TaskStateDropdown}
-                  id={"task-state-#{@task.id}"}
-                  task={@task}
-                  current_user={@current_user}
-                  current_workspace={@current_workspace}
-                  size="size-5"
-                />
-              <% else %>
-                <.task_state_icon task_state={@task.task_state} size="size-5" />
-              <% end %>
-              <%= if @can_edit do %>
-                <input
-                  type="text"
-                  name="title"
-                  value={@task.title}
-                  phx-blur="save-title"
-                  phx-keydown="save-title"
-                  phx-key="Enter"
-                  class="input input-ghost text-2xl font-bold flex-1 p-0 h-auto min-h-0 focus:outline-none focus:bg-base-300/50 rounded"
-                />
-              <% else %>
-                <h1 class="card-title text-2xl">{@task.title}</h1>
-              <% end %>
-            </div>
-            <div class="flex gap-2">
-              <.button
-                :if={@can_delete}
-                class="btn btn-sm btn-secondary text-error"
-                phx-click="confirm_delete"
-              >
-                <.icon name="hero-trash" class="size-4" /> Delete
-              </.button>
-            </div>
-          </div>
-
-          <div class="pt-4"></div>
-
-          <div class="grid grid-cols-[1fr_20rem] gap-4">
-            <div class="py-4">
-              <h2 class="text-sm font-semibold text-base-content/70 mb-2">Description</h2>
-              <div
-                id={"description-editor-#{@task.id}"}
-                phx-hook="MilkdownEditor"
-                phx-update="ignore"
-                data-content={@task.description || ""}
-                data-readonly={to_string(not @can_edit)}
-                class="milkdown-container prose max-w-none"
-              />
-            </div>
-
-            <div class="border-l border-base-300 p-4">
-              <div class="sticky top-0 space-y-5">
-                <div class="flex items-center justify-between gap-4">
-                  <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
-                    Priority
-                  </label>
-                  <%= if @can_edit do %>
-                    <.live_component
-                      module={CitadelWeb.Components.PriorityDropdown}
-                      id={"task-priority-#{@task.id}"}
-                      task={@task}
-                      current_user={@current_user}
-                      current_workspace={@current_workspace}
-                      align_right={true}
-                    />
-                  <% else %>
-                    <.priority_badge priority={@task.priority} />
-                  <% end %>
-                </div>
-
-                <div class="flex items-center justify-between gap-4">
-                  <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
-                    Assignees
-                  </label>
-                  <%= if @can_edit do %>
-                    <.live_component
-                      module={CitadelWeb.Components.AssigneeSelect}
-                      id={"task-assignees-#{@task.id}"}
-                      workspace={@current_workspace}
-                      selected_ids={Enum.map(@task.assignees, & &1.id)}
-                      field_name="assignees[]"
-                      current_user={@current_user}
-                      on_change={true}
-                      compact={true}
-                    />
-                  <% else %>
-                    <%= if Enum.empty?(@task.assignees) do %>
-                      <span class="text-sm text-base-content/40">Unassigned</span>
-                    <% else %>
-                      <div class="flex flex-wrap gap-1">
-                        <.user_avatar
-                          :for={assignee <- @task.assignees}
-                          user={assignee}
-                          size="w-7 h-7"
-                        />
-                      </div>
-                    <% end %>
-                  <% end %>
-                </div>
-
-                <div class="flex items-center justify-between gap-4">
-                  <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
-                    Due Date
-                  </label>
-                  <%= if @can_edit do %>
-                    <input
-                      type="text"
-                      name="due_date"
-                      value={@task.due_date}
-                      phx-blur="save-due-date"
-                      placeholder="None"
-                      onfocus="this.type='date'"
-                      class={[
-                        "input input-ghost text-sm text-right p-0 h-auto min-h-0 border-0 placeholder:text-base-content/60",
-                        @task.overdue? && "text-error",
-                        @task.due_date && !@task.overdue? && "text-base-content/80"
-                      ]}
-                    />
-                  <% else %>
-                    <span class={[
-                      "text-sm",
-                      @task.overdue? && "text-error",
-                      !@task.due_date && "text-base-content/40"
-                    ]}>
-                      {if @task.due_date,
-                        do: Calendar.strftime(@task.due_date, "%b %d, %Y"),
-                        else: "Not set"}
-                    </span>
-                  <% end %>
-                </div>
-
-                <div class="flex items-center justify-between gap-4">
-                  <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
-                    Project
-                  </label>
-                  <%= if @task.project do %>
-                    <span class="text-sm text-base-content/80">{@task.project.name}</span>
-                  <% else %>
-                    <span class="text-sm text-base-content/40">None</span>
-                  <% end %>
-                </div>
-
-                <div
-                  :if={@task.execution_status != :none}
-                  class="flex items-center justify-between gap-4"
-                >
-                  <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
-                    Execution
-                  </label>
-                  <span class={[
-                    "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
-                    execution_status_classes(@task.execution_status)
-                  ]}>
-                    <span class={[
-                      "size-1.5 rounded-full",
-                      execution_status_dot_class(@task.execution_status)
-                    ]} />
-                    {@task.execution_status}
-                  </span>
-                </div>
-
-                <div class="flex items-center justify-between gap-4">
-                  <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
-                    Agent
-                  </label>
-                  <%= if @can_edit do %>
-                    <button
-                      phx-click="toggle_agent_eligible"
-                      class={[
-                        "flex items-center gap-1.5 text-sm px-2 py-0.5 rounded-full transition-colors cursor-pointer",
-                        if(@task.agent_eligible,
-                          do: "bg-emerald-500/15 text-emerald-400",
-                          else: "bg-base-300/50 text-base-content/40 hover:text-base-content/60"
-                        )
-                      ]}
-                    >
-                      <.icon
-                        name={
-                          if(@task.agent_eligible, do: "hero-cpu-chip-solid", else: "hero-cpu-chip")
-                        }
-                        class="size-3.5"
-                      />
-                      {if @task.agent_eligible, do: "Eligible", else: "Not eligible"}
-                    </button>
-                  <% else %>
-                    <span class={[
-                      "text-sm",
-                      if(@task.agent_eligible, do: "text-emerald-400", else: "text-base-content/40")
-                    ]}>
-                      {if @task.agent_eligible, do: "Eligible", else: "Not eligible"}
-                    </span>
-                  <% end %>
-                </div>
-
-                <% {pr_label, pr_text} = forge_pr_label(@task.forge_pr) %>
-                <div class="flex items-center justify-between gap-4">
-                  <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
-                    {pr_label}
-                  </label>
-                  <%= if @task.forge_pr do %>
-                    <a
-                      href={@task.forge_pr}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="inline-flex items-center gap-1.5 text-sm text-base-content/80 hover:text-primary transition-colors"
-                    >
-                      {pr_text}
-                      <.icon name="hero-arrow-top-right-on-square" class="size-3.5" />
-                    </a>
-                  <% else %>
-                    <span class="text-sm text-base-content/40">None</span>
-                  <% end %>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <.live_component
-            module={CitadelWeb.Components.TaskDependencies}
-            id={"task-dependencies-#{@task.id}"}
-            task={@task}
-            task_dependencies={@task_dependencies}
-            can_edit={@can_edit}
-            current_user={@current_user}
-            current_workspace={@current_workspace}
-          />
-
-          <div class="py-4 border-t border-base-300">
-            <div class="flex items-center justify-between mb-3 mr-6">
-              <h2 class="text-sm font-semibold text-base-content/70">
-                Sub-tasks ({@sub_tasks_count})
-              </h2>
-              <.button :if={@can_edit} class="btn btn-xs btn-secondary" phx-click="new-sub-task">
-                <.icon name="hero-plus" class="size-3" /> Add
-              </.button>
-            </div>
-
-            <%= if @sub_tasks_count == 0 do %>
-              <p class="text-base-content/50 italic text-sm">No sub-tasks</p>
-            <% else %>
-              <.live_component
-                module={CitadelWeb.Components.TasksListComponent}
-                id={"sub-tasks-#{@task.id}"}
-                tasks={@sub_tasks}
+        <div class="h-full overflow-auto">
+          <%= cond do %>
+            <% @load_error -> %>
+              <.load_error human_id={@human_id} />
+            <% @task -> %>
+              <.task_content
+                task={@task}
+                sub_tasks={@sub_tasks}
+                sub_tasks_count={@sub_tasks_count}
+                activities={@activities}
+                can_edit={@can_edit}
+                can_delete={@can_delete}
                 current_user={@current_user}
                 current_workspace={@current_workspace}
               />
-            <% end %>
-          </div>
-
-          <.live_component
-            module={TaskActivitySection}
-            id={"task-activities-#{@task.id}"}
-            task={@task}
-            current_user={@current_user}
-            current_workspace={@current_workspace}
-            can_edit={@can_edit}
-          />
+            <% true -> %>
+              <.task_skeleton />
+          <% end %>
         </div>
       </div>
 
       <.live_component
-        :if={@show_sub_task_form}
+        :if={@show_sub_task_form and @task}
         module={CitadelWeb.Components.NewTaskModal}
         id="new-sub-task-modal"
         current_user={@current_user}
@@ -959,6 +622,332 @@ defmodule CitadelWeb.TaskLive.Show do
         on_cancel="cancel_cancel_run"
       />
     </Layouts.app>
+    """
+  end
+
+  attr :human_id, :string, required: true
+
+  defp load_error(assigns) do
+    ~H"""
+    <div class="alert alert-error max-w-xl mx-auto mt-8">
+      <.icon name="hero-exclamation-triangle" class="size-5" />
+      <span>Failed to load task {@human_id}.</span>
+      <.link navigate={~p"/dashboard"} class="btn btn-sm btn-outline">Back to dashboard</.link>
+    </div>
+    """
+  end
+
+  defp task_skeleton(assigns) do
+    ~H"""
+    <div class="space-y-4" data-testid="task-skeleton">
+      <div class="skeleton h-4 w-40"></div>
+      <div class="flex items-center gap-3">
+        <div class="skeleton size-5 shrink-0 rounded-full"></div>
+        <div class="skeleton h-8 w-2/3"></div>
+      </div>
+      <div class="grid grid-cols-[1fr_20rem] gap-4 pt-4">
+        <div class="space-y-3">
+          <div class="skeleton h-4 w-24"></div>
+          <div class="skeleton h-24 w-full"></div>
+        </div>
+        <div class="space-y-3 border-l border-base-300 p-4">
+          <div class="skeleton h-4 w-32"></div>
+          <div class="skeleton h-4 w-40"></div>
+          <div class="skeleton h-4 w-28"></div>
+          <div class="skeleton h-4 w-36"></div>
+          <div class="skeleton h-4 w-24"></div>
+        </div>
+      </div>
+      <div class="space-y-3 pt-4 border-t border-base-300">
+        <div class="skeleton h-4 w-32"></div>
+        <div class="skeleton h-10 w-full max-w-lg"></div>
+      </div>
+      <div class="space-y-3 pt-4 border-t border-base-300">
+        <div class="skeleton h-4 w-24"></div>
+        <div class="skeleton h-12 w-full"></div>
+        <div class="skeleton h-12 w-full"></div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :task, :any, required: true
+  attr :sub_tasks, :list, required: true
+  attr :sub_tasks_count, :integer, required: true
+  attr :activities, :list, required: true
+  attr :can_edit, :boolean, required: true
+  attr :can_delete, :boolean, required: true
+  attr :current_user, :any, required: true
+  attr :current_workspace, :any, required: true
+
+  defp task_content(assigns) do
+    ~H"""
+    <div class="breadcrumbs text-sm mb-4">
+      <ul>
+        <li><.link navigate={~p"/dashboard"}>Tasks</.link></li>
+        <li :for={ancestor <- @task.ancestors}>
+          <.link navigate={~p"/tasks/#{ancestor.human_id}"}>{ancestor.human_id}</.link>
+        </li>
+        <li><span>{@task.human_id}</span></li>
+      </ul>
+    </div>
+
+    <div class="flex items-start justify-between pr-3">
+      <div class="flex items-center gap-3 flex-1">
+        <%= if @can_edit do %>
+          <.live_component
+            module={CitadelWeb.Components.TaskStateDropdown}
+            id={"task-state-#{@task.id}"}
+            task={@task}
+            current_user={@current_user}
+            current_workspace={@current_workspace}
+            size="size-5"
+          />
+        <% else %>
+          <.task_state_icon task_state={@task.task_state} size="size-5" />
+        <% end %>
+        <%= if @can_edit do %>
+          <input
+            type="text"
+            name="title"
+            value={@task.title}
+            phx-blur="save-title"
+            phx-keydown="save-title"
+            phx-key="Enter"
+            class="input input-ghost text-2xl font-bold flex-1 p-0 h-auto min-h-0 focus:outline-none focus:bg-base-300/50 rounded"
+          />
+        <% else %>
+          <h1 class="card-title text-2xl">{@task.title}</h1>
+        <% end %>
+      </div>
+      <div class="flex gap-2">
+        <.button
+          :if={@can_delete}
+          class="btn btn-sm btn-secondary text-error"
+          phx-click="confirm_delete"
+        >
+          <.icon name="hero-trash" class="size-4" /> Delete
+        </.button>
+      </div>
+    </div>
+
+    <div class="pt-4"></div>
+
+    <div class="grid grid-cols-[1fr_20rem] gap-4">
+      <div class="py-4">
+        <h2 class="text-sm font-semibold text-base-content/70 mb-2">Description</h2>
+        <div
+          id={"description-editor-#{@task.id}"}
+          phx-hook="MilkdownEditor"
+          phx-update="ignore"
+          data-content={@task.description || ""}
+          data-readonly={to_string(not @can_edit)}
+          class="milkdown-container prose max-w-none"
+        />
+      </div>
+
+      <div class="border-l border-base-300 p-4">
+        <div class="sticky top-0 space-y-5">
+          <div class="flex items-center justify-between gap-4">
+            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+              Priority
+            </label>
+            <%= if @can_edit do %>
+              <.live_component
+                module={CitadelWeb.Components.PriorityDropdown}
+                id={"task-priority-#{@task.id}"}
+                task={@task}
+                current_user={@current_user}
+                current_workspace={@current_workspace}
+                align_right={true}
+              />
+            <% else %>
+              <.priority_badge priority={@task.priority} />
+            <% end %>
+          </div>
+
+          <div class="flex items-center justify-between gap-4">
+            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+              Assignees
+            </label>
+            <%= if @can_edit do %>
+              <.live_component
+                module={CitadelWeb.Components.AssigneeSelect}
+                id={"task-assignees-#{@task.id}"}
+                workspace={@current_workspace}
+                selected_ids={Enum.map(@task.assignees, & &1.id)}
+                field_name="assignees[]"
+                current_user={@current_user}
+                on_change={true}
+                compact={true}
+              />
+            <% else %>
+              <%= if Enum.empty?(@task.assignees) do %>
+                <span class="text-sm text-base-content/40">Unassigned</span>
+              <% else %>
+                <div class="flex flex-wrap gap-1">
+                  <.user_avatar :for={assignee <- @task.assignees} user={assignee} size="w-7 h-7" />
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+
+          <div class="flex items-center justify-between gap-4">
+            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+              Due Date
+            </label>
+            <%= if @can_edit do %>
+              <input
+                type="text"
+                name="due_date"
+                value={@task.due_date}
+                phx-blur="save-due-date"
+                placeholder="None"
+                onfocus="this.type='date'"
+                class={[
+                  "input input-ghost text-sm text-right p-0 h-auto min-h-0 border-0 placeholder:text-base-content/60",
+                  @task.overdue? && "text-error",
+                  @task.due_date && !@task.overdue? && "text-base-content/80"
+                ]}
+              />
+            <% else %>
+              <span class={[
+                "text-sm",
+                @task.overdue? && "text-error",
+                !@task.due_date && "text-base-content/40"
+              ]}>
+                {if @task.due_date,
+                  do: Calendar.strftime(@task.due_date, "%b %d, %Y"),
+                  else: "Not set"}
+              </span>
+            <% end %>
+          </div>
+
+          <div class="flex items-center justify-between gap-4">
+            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+              Project
+            </label>
+            <%= if @task.project do %>
+              <span class="text-sm text-base-content/80">{@task.project.name}</span>
+            <% else %>
+              <span class="text-sm text-base-content/40">None</span>
+            <% end %>
+          </div>
+
+          <div
+            :if={@task.execution_status != :none}
+            class="flex items-center justify-between gap-4"
+          >
+            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+              Execution
+            </label>
+            <span class={[
+              "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
+              execution_status_classes(@task.execution_status)
+            ]}>
+              <span class={[
+                "size-1.5 rounded-full",
+                execution_status_dot_class(@task.execution_status)
+              ]} />
+              {@task.execution_status}
+            </span>
+          </div>
+
+          <div class="flex items-center justify-between gap-4">
+            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+              Agent
+            </label>
+            <%= if @can_edit do %>
+              <button
+                phx-click="toggle_agent_eligible"
+                class={[
+                  "flex items-center gap-1.5 text-sm px-2 py-0.5 rounded-full transition-colors cursor-pointer",
+                  if(@task.agent_eligible,
+                    do: "bg-emerald-500/15 text-emerald-400",
+                    else: "bg-base-300/50 text-base-content/40 hover:text-base-content/60"
+                  )
+                ]}
+              >
+                <.icon
+                  name={if(@task.agent_eligible, do: "hero-cpu-chip-solid", else: "hero-cpu-chip")}
+                  class="size-3.5"
+                />
+                {if @task.agent_eligible, do: "Eligible", else: "Not eligible"}
+              </button>
+            <% else %>
+              <span class={[
+                "text-sm",
+                if(@task.agent_eligible, do: "text-emerald-400", else: "text-base-content/40")
+              ]}>
+                {if @task.agent_eligible, do: "Eligible", else: "Not eligible"}
+              </span>
+            <% end %>
+          </div>
+
+          <% {pr_label, pr_text} = forge_pr_label(@task.forge_pr) %>
+          <div class="flex items-center justify-between gap-4">
+            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+              {pr_label}
+            </label>
+            <%= if @task.forge_pr do %>
+              <a
+                href={@task.forge_pr}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1.5 text-sm text-base-content/80 hover:text-primary transition-colors"
+              >
+                {pr_text}
+                <.icon name="hero-arrow-top-right-on-square" class="size-3.5" />
+              </a>
+            <% else %>
+              <span class="text-sm text-base-content/40">None</span>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <.live_component
+      module={CitadelWeb.Components.TaskDependencies}
+      id={"task-dependencies-#{@task.id}"}
+      task={@task}
+      can_edit={@can_edit}
+      current_user={@current_user}
+      current_workspace={@current_workspace}
+    />
+
+    <div class="py-4 border-t border-base-300">
+      <div class="flex items-center justify-between mb-3 mr-6">
+        <h2 class="text-sm font-semibold text-base-content/70">
+          Sub-tasks ({@sub_tasks_count})
+        </h2>
+        <.button :if={@can_edit} class="btn btn-xs btn-secondary" phx-click="new-sub-task">
+          <.icon name="hero-plus" class="size-3" /> Add
+        </.button>
+      </div>
+
+      <%= if @sub_tasks_count == 0 do %>
+        <p class="text-base-content/50 italic text-sm">No sub-tasks</p>
+      <% else %>
+        <.live_component
+          module={CitadelWeb.Components.TasksListComponent}
+          id={"sub-tasks-#{@task.id}"}
+          tasks={@sub_tasks}
+          current_user={@current_user}
+          current_workspace={@current_workspace}
+        />
+      <% end %>
+    </div>
+
+    <.live_component
+      module={TaskActivitySection}
+      id={"task-activities-#{@task.id}"}
+      task={@task}
+      activities={@activities}
+      current_user={@current_user}
+      current_workspace={@current_workspace}
+      can_edit={@can_edit}
+    />
     """
   end
 end

--- a/test/citadel_web/live/task_live/show_activity_test.exs
+++ b/test/citadel_web/live/task_live/show_activity_test.exs
@@ -34,20 +34,23 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
 
   describe "activity section rendering" do
     test "displays activity section heading", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Activity"
     end
 
     test "displays comment form", %{conn: conn, task: task, component_id: cid} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       assert has_element?(view, "##{cid}-form")
       assert has_element?(view, ~s|##{cid}-form textarea[name="comment[body]"]|)
     end
 
     test "displays empty state when no activities", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "No activity yet"
     end
@@ -60,6 +63,7 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
       component_id: cid
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       html =
         view
@@ -75,6 +79,7 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
       component_id: cid
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> form("##{cid}-form", %{comment: %{body: "Comment to clear"}})
@@ -95,6 +100,7 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
       component_id: cid
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> form("##{cid}-form", %{comment: %{body: ""}})
@@ -112,6 +118,7 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
       component_id: cid
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> form("##{cid}-form", %{comment: %{body: "   "}})
@@ -135,7 +142,8 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "User comment"
       assert html =~ to_string(user.email)
@@ -155,7 +163,8 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
         )
       end
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Comment 1"
       assert html =~ "Comment 2"
@@ -174,7 +183,8 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "just now"
     end
@@ -195,6 +205,7 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       assert has_element?(
                view,
@@ -216,6 +227,7 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       html =
         view
@@ -234,6 +246,7 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
       workspace: workspace
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       Tasks.create_comment!(
         %{body: "Real-time comment", task_id: task.id},
@@ -260,7 +273,8 @@ defmodule CitadelWeb.TaskLive.ShowActivityTest do
           tenant: workspace.id
         )
 
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
       assert html =~ "Soon to be deleted"
 
       Tasks.destroy_comment!(activity, actor: user, tenant: workspace.id)

--- a/test/citadel_web/live/task_live/show_agent_run_activity_test.exs
+++ b/test/citadel_web/live/task_live/show_agent_run_activity_test.exs
@@ -57,7 +57,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
         authorize?: false
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Activity"
       assert html =~ "Agent"
@@ -93,7 +94,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
         authorize?: false
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "failed"
       assert html =~ "Test failure: expected 200, got 500"
@@ -134,7 +136,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
         authorize?: false
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Commits (2)"
       assert html =~ "abc1234"
@@ -172,7 +175,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
         authorize?: false
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Test Output"
       assert html =~ "12 tests, 0 failures"
@@ -207,7 +211,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
         authorize?: false
       )
 
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "running"
       assert has_element?(view, "button", "Cancel")
@@ -244,6 +249,7 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       refute has_element?(
                view,
@@ -292,7 +298,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Starting work on this"
       assert html =~ "completed"
@@ -328,7 +335,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
         authorize?: false
       )
 
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       refute has_element?(view, "#agent-runs-section")
       refute html =~ "Agent Runs"
@@ -386,7 +394,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
         authorize?: false
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "failed"
       assert html =~ "Tests failed"
@@ -402,7 +411,8 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
       workspace: workspace,
       task: task
     } do
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "No activity yet"
 
@@ -462,6 +472,7 @@ defmodule CitadelWeb.TaskLive.ShowAgentRunActivityTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       assert render(view) =~ "running"
 

--- a/test/citadel_web/live/task_live/show_test.exs
+++ b/test/citadel_web/live/task_live/show_test.exs
@@ -25,19 +25,22 @@ defmodule CitadelWeb.TaskLive.ShowTest do
     end
 
     test "displays task title", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Test Task"
     end
 
     test "displays task human_id in breadcrumbs", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ task.human_id
     end
 
     test "displays priority badge", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "medium"
     end
@@ -76,6 +79,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "saves title on blur", %{conn: conn, task: task, user: user, workspace: workspace} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("input[name=\"title\"]")
@@ -92,6 +96,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "saves title on Enter key", %{conn: conn, task: task, user: user, workspace: workspace} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("input[name=\"title\"]")
@@ -108,6 +113,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "does not save empty title", %{conn: conn, task: task, user: user, workspace: workspace} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("input[name=\"title\"]")
@@ -129,6 +135,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       workspace: workspace
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("input[name=\"title\"]")
@@ -144,7 +151,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
     end
 
     test "preserves sub-tasks after title update", %{conn: conn, task: task, sub_task: sub_task} do
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ sub_task.title
 
@@ -178,6 +186,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "saves due date on blur", %{conn: conn, task: task, user: user, workspace: workspace} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("input[name=\"due_date\"]")
@@ -211,6 +220,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("input[name=\"due_date\"]")
@@ -245,7 +255,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
           )
         )
 
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ sub_task.title
 
@@ -278,7 +289,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
     end
 
     test "displays current priority", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "low"
     end
@@ -290,6 +302,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       workspace: workspace
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("#task-priority-#{task.id} button[phx-value-priority=\"high\"]")
@@ -306,6 +319,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "updates UI after priority change", %{conn: conn, task: task} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       html =
         view
@@ -335,7 +349,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
           )
         )
 
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ sub_task.title
 
@@ -369,18 +384,21 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "displays assignee select component", %{conn: conn, task: task} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       assert has_element?(view, "#task-assignees-#{task.id}")
     end
 
     test "shows 'None' when no assignees", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "None"
     end
 
     test "can toggle assignee dropdown", %{conn: conn, task: task} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("#task-assignees-#{task.id} > div[phx-click=\"toggle\"]")
@@ -394,6 +412,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "toggles member selection in UI", %{conn: conn, task: task, user: user} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("#task-assignees-#{task.id} > div[phx-click=\"toggle\"]")
@@ -427,7 +446,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
           )
         )
 
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ sub_task.title
 
@@ -467,6 +487,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "displays task state dropdown", %{conn: conn, task: task} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       assert has_element?(view, "#task-state-#{task.id}")
     end
@@ -480,6 +501,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       workspace: workspace
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element("#task-state-#{task.id} button[phx-value-state-id=\"#{done_state.id}\"]")
@@ -516,7 +538,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
           )
         )
 
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ sub_task.title
 
@@ -571,6 +594,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       workspace: workspace
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       # Simulate the drag-and-drop by sending the task-moved event to the component
       view
@@ -597,7 +621,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       sub_task: sub_task,
       done_state: done_state
     } do
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Sub-tasks (1)"
       assert html =~ sub_task.title
@@ -638,9 +663,10 @@ defmodule CitadelWeb.TaskLive.ShowTest do
     end
 
     test "non-member cannot access task", %{conn: conn, task: task} do
-      assert_raise Ash.Error.Invalid, fn ->
-        live(conn, ~p"/tasks/#{task.human_id}")
-      end
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
+
+      assert html =~ "Failed to load task"
     end
   end
 
@@ -664,13 +690,15 @@ defmodule CitadelWeb.TaskLive.ShowTest do
     end
 
     test "displays dependencies section when task loads", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Blocked by"
     end
 
     test "displays 'Blocks' section for dependents", %{conn: conn, task: task} do
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Blocked by"
     end
@@ -692,6 +720,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       html =
         view
@@ -704,6 +733,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
     test "shows error for invalid human_id", %{conn: conn, task: task} do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       html =
         view
@@ -738,6 +768,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
 
       # Try to create B→A (circular)
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task_b.human_id}")
+      render_async(view)
 
       html =
         view
@@ -771,6 +802,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       html =
         view
@@ -805,7 +837,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "badge badge-warning"
       assert html =~ ">Blocked</span>"
@@ -833,7 +866,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       refute html =~ "badge badge-warning"
     end
@@ -862,6 +896,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       html =
         view
@@ -897,6 +932,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       # Trigger completion warning
       view
@@ -947,6 +983,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       # Trigger completion warning
       view
@@ -993,7 +1030,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Blocks"
       assert html =~ dependent_task.human_id
@@ -1007,6 +1045,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       workspace: workspace
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       dependency_task =
         generate(
@@ -1054,7 +1093,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
           tenant: workspace.id
         )
 
-      {:ok, view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
       assert html =~ dependency_task.human_id
 
       # Remove dependency in another process
@@ -1074,6 +1114,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       workspace: workspace
     } do
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       # Try to submit with empty human_id
       view
@@ -1131,7 +1172,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "completed"
     end
@@ -1165,7 +1207,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "Commits (2)"
       assert html =~ "abc1234"
@@ -1193,7 +1236,8 @@ defmodule CitadelWeb.TaskLive.ShowTest do
         tenant: workspace.id
       )
 
-      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.human_id}")
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      html = render_async(view)
 
       assert html =~ "failed"
       assert html =~ "Tests failed"
@@ -1231,6 +1275,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       run = create_agent_run_with_activity(task, user, workspace)
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       assert has_element?(
                view,
@@ -1252,6 +1297,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       assert has_element?(
                view,
@@ -1273,6 +1319,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       refute has_element?(view, ~s|button[phx-click="request-cancel-agent-run"]|)
     end
@@ -1291,6 +1338,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       refute has_element?(view, ~s|button[phx-click="request-cancel-agent-run"]|)
     end
@@ -1304,6 +1352,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       run = create_agent_run_with_activity(task, user, workspace)
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element(~s|button[phx-click="request-cancel-agent-run"][phx-value-run-id="#{run.id}"]|)
@@ -1324,6 +1373,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       run = create_agent_run_with_activity(task, user, workspace)
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element(~s|button[phx-click="request-cancel-agent-run"][phx-value-run-id="#{run.id}"]|)
@@ -1351,6 +1401,7 @@ defmodule CitadelWeb.TaskLive.ShowTest do
       run = create_agent_run_with_activity(task, user, workspace)
 
       {:ok, view, _html} = live(conn, ~p"/tasks/#{task.human_id}")
+      render_async(view)
 
       view
       |> element(~s|button[phx-click="request-cancel-agent-run"][phx-value-run-id="#{run.id}"]|)


### PR DESCRIPTION
## Summary
- Render `TaskLive.Show` immediately with placeholders and load the task, sub-tasks, and activities concurrently via `start_async` + `Task.async_stream`, so the page no longer blocks mount on serial Ash queries.
- Add a `dependency_records` `has_many` on `Citadel.Tasks.Task` so `TaskDependencies` builds its `dep_map` from the preloaded relationship instead of a separate `list_task_dependencies` call.
- Hoist activity fetching out of `TaskActivitySection` — the parent LiveView now owns the data load and passes activities in via assigns.

## Test plan
- [ ] `mix ck`
- [ ] `mix test test/citadel_web/live/task_live/show_test.exs test/citadel_web/live/task_live/show_activity_test.exs test/citadel_web/live/task_live/show_agent_run_activity_test.exs`
- [ ] Manual: open a task with dependencies, sub-tasks, and activity history; confirm the page renders the skeleton state and then fills in without flicker, and dependency add/remove still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)