### PR TITLE
P-2: feat: auto-create TaskActivity on AgentRun creation

### DIFF
--- a/lib/citadel/tasks/changes/create_agent_run_activity.ex
+++ b/lib/citadel/tasks/changes/create_agent_run_activity.ex
@@ -7,7 +7,8 @@ defmodule Citadel.Tasks.Changes.CreateAgentRunActivity do
     Ash.Changeset.after_action(changeset, fn _changeset, agent_run ->
       Citadel.Tasks.create_agent_run_activity!(
         %{task_id: agent_run.task_id, agent_run_id: agent_run.id},
-        tenant: agent_run.workspace_id
+        tenant: agent_run.workspace_id,
+        authorize?: false
       )
 
       {:ok, agent_run}


### PR DESCRIPTION
## Summary

Wires `CreateAgentRunActivity` into both `AgentRun` creation actions so that every new agent run automatically produces a linked `TaskActivity` record.

## Changes

- Added `change Citadel.Tasks.Changes.CreateAgentRunActivity` to the `create` action in `lib/citadel/tasks/agent_run.ex`, after `InheritTaskWorkspace`
- Added `change Citadel.Tasks.Changes.CreateAgentRunActivity` to the `claim_next` action in `lib/citadel/tasks/agent_run.ex`, after `ClaimNextTask`

## Why the order matters

Both `InheritTaskWorkspace` (in `create`) and `ClaimNextTask` (in `claim_next`) are responsible for populating `workspace_id` and `task_id` on the changeset. `CreateAgentRunActivity` reads those values to build the activity record, so it must run after them.

## Acceptance Criteria

- [x] `create` action includes `CreateAgentRunActivity`
- [x] `claim_next` action includes `CreateAgentRunActivity`
- [x] Creating an agent run via either action produces a linked `TaskActivity` record

## Dependencies

Depends on the `CreateAgentRunActivity` change module introduced in the preceding subtask.