### PR TITLE
fix(agent-runs): re-render todo panel on TodoWrite broadcasts

### DIFF
--- a/lib/citadel_web/live/agent_run_live.ex
+++ b/lib/citadel_web/live/agent_run_live.ex
@@ -298,12 +298,13 @@ defmodule CitadelWeb.AgentRunLive do
     progress = if total > 0, do: round(done / total * 100), else: 0
 
     assigns =
-      assigns
-      |> Map.put(:remaining, remaining)
-      |> Map.put(:completed, completed)
-      |> Map.put(:total, total)
-      |> Map.put(:done, done)
-      |> Map.put(:progress, progress)
+      assign(assigns,
+        remaining: remaining,
+        completed: completed,
+        total: total,
+        done: done,
+        progress: progress
+      )
 
     ~H"""
     <div class="border-t border-base-300 pt-3 mt-3 shrink-0">


### PR DESCRIPTION
## Summary

- `todo_panel/1` in `AgentRunLive` derived `:remaining`, `:completed`, `:total`, `:done`, `:progress` from `@todos` and added them via `Map.put`. That bypassed Phoenix's `__changed__` tracker, so the heex compiler reused the first render's cached values for `@done`/`@total`/etc. forever.
- Symptom: live agent runs rendered the initial TodoWrite list correctly, but every subsequent broadcast left the panel stuck at "0/X" with nothing checked off — even though `socket.assigns.todos` was being updated in `handle_info`.
- Fix: switch the derived-assign pipeline to `Phoenix.Component.assign/2` so `__changed__` is updated and the heex compiler re-renders on subsequent updates.

## Test plan

- [x] Reproduced bug locally: opened a live `/agent-runs/:id`, broadcast a second TodoWrite via `Tasks.create_agent_run_event`, page stayed at "0/2" while `:sys.get_state` on the LV showed correct todos.
- [x] Verified fix: same flow now updates the rendered "X/Y" header and strikes through completed items live as broadcasts arrive.
- [ ] Worth eyeballing on a real live agent run end-to-end before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)