### PR TITLE
feat(agents): move agent settings to dedicated card on workspace details page

### DIFF
--- a/lib/citadel_web/live/preferences_live/components/agent_settings_card.ex
+++ b/lib/citadel_web/live/preferences_live/components/agent_settings_card.ex
@@ -1,0 +1,169 @@
+defmodule CitadelWeb.PreferencesLive.Components.AgentSettingsCard do
+  @moduledoc false
+
+  use CitadelWeb, :live_component
+
+  require OpentelemetryPhoenixLiveViewProcessPropagator.LiveView, as: TracedLV
+  require OpenTelemetry.Tracer, as: Tracer
+
+  alias Citadel.Accounts
+  alias Phoenix.LiveView.AsyncResult
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     socket
+     |> assign(:workspace_async, AsyncResult.loading())
+     |> assign(:form, nil)
+     |> assign(:load_started?, false)}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(:id, assigns.id)
+      |> assign(:workspace_id, assigns.workspace_id)
+      |> assign(:current_user, assigns.current_user)
+      |> assign(:is_owner, assigns.is_owner)
+      |> maybe_start_load()
+
+    {:ok, socket}
+  end
+
+  defp maybe_start_load(%{assigns: %{load_started?: true}} = socket), do: socket
+
+  defp maybe_start_load(socket) do
+    workspace_id = socket.assigns.workspace_id
+    user = socket.assigns.current_user
+
+    socket
+    |> assign(:load_started?, true)
+    |> TracedLV.start_async(:load_workspace, fn -> load_workspace(workspace_id, user) end)
+  end
+
+  @impl true
+  def handle_async(:load_workspace, {:ok, {:ok, workspace}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:workspace_async, AsyncResult.ok(socket.assigns.workspace_async, workspace))
+     |> assign(:form, build_form(workspace, socket.assigns.current_user, socket.assigns.is_owner))}
+  end
+
+  def handle_async(:load_workspace, {:ok, {:error, reason}}, socket),
+    do:
+      {:noreply,
+       assign(
+         socket,
+         :workspace_async,
+         AsyncResult.failed(socket.assigns.workspace_async, reason)
+       )}
+
+  def handle_async(:load_workspace, {:exit, reason}, socket),
+    do:
+      {:noreply,
+       assign(
+         socket,
+         :workspace_async,
+         AsyncResult.failed(socket.assigns.workspace_async, {:exit, reason})
+       )}
+
+  @impl true
+  def handle_event("save", %{"form" => params}, socket) do
+    case AshPhoenix.Form.submit(socket.assigns.form,
+           params: params,
+           action_opts: [actor: socket.assigns.current_user]
+         ) do
+      {:ok, workspace} ->
+        {:noreply,
+         socket
+         |> assign(:workspace_async, AsyncResult.ok(socket.assigns.workspace_async, workspace))
+         |> assign(
+           :form,
+           build_form(workspace, socket.assigns.current_user, socket.assigns.is_owner)
+         )
+         |> put_flash(:info, "Agent settings updated")}
+
+      {:error, form} ->
+        {:noreply, assign(socket, :form, form)}
+    end
+  end
+
+  defp build_form(_workspace, _user, false), do: nil
+
+  defp build_form(workspace, user, true) do
+    workspace
+    |> AshPhoenix.Form.for_update(:update, actor: user)
+    |> to_form()
+  end
+
+  defp load_workspace(workspace_id, user) do
+    Tracer.with_span "agent_settings_card.load.workspace",
+      attributes: %{"workspace.id" => workspace_id} do
+      Accounts.get_workspace_by_id(workspace_id, actor: user)
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <.card class="bg-base-200 border-base-300">
+        <:title>Agent Settings</:title>
+
+        <.async_result :let={workspace} assign={@workspace_async}>
+          <:loading>
+            <div class="flex items-start justify-between gap-4 py-2">
+              <div class="flex-1 min-w-0 space-y-2">
+                <div class="skeleton h-4 w-48"></div>
+                <div class="skeleton h-3 w-full"></div>
+                <div class="skeleton h-3 w-3/4"></div>
+              </div>
+              <div class="skeleton h-9 w-32 shrink-0"></div>
+            </div>
+          </:loading>
+          <:failed :let={_reason}>
+            <p class="text-error text-sm italic">Failed to load agent settings.</p>
+          </:failed>
+
+          <div class="flex items-start justify-between gap-4 py-2">
+            <div class="flex-1 min-w-0">
+              <h4 class="font-medium">Max agent run duration</h4>
+              <p class="text-sm text-base-content/70 mt-1">
+                Hard wallclock cap on a single Claude Code run. Range 60&ndash;86400 seconds (default 14400 / 4 hours). Agents pick up changes on their next reconnect.
+              </p>
+            </div>
+
+            <%= if @is_owner do %>
+              <.form
+                for={@form}
+                id="agent-settings-form"
+                phx-submit="save"
+                phx-target={@myself}
+                class="flex items-end gap-2 shrink-0"
+              >
+                <div>
+                  <.input
+                    field={@form[:agent_max_run_seconds]}
+                    type="number"
+                    label="Seconds"
+                    min="60"
+                    max="86400"
+                    required
+                  />
+                </div>
+                <.button type="submit" variant="primary">Save</.button>
+              </.form>
+            <% else %>
+              <div class="shrink-0 text-right">
+                <div class="text-lg font-semibold">{workspace.agent_max_run_seconds}s</div>
+                <div class="text-xs text-base-content/60">read-only</div>
+              </div>
+            <% end %>
+          </div>
+        </.async_result>
+      </.card>
+    </div>
+    """
+  end
+end

--- a/lib/citadel_web/live/preferences_live/workspace.ex
+++ b/lib/citadel_web/live/preferences_live/workspace.ex
@@ -30,7 +30,8 @@ defmodule CitadelWeb.PreferencesLive.Workspace do
          |> assign(:memberships, memberships)
          |> assign(:invitations, invitations)
          |> assign(:is_owner, is_owner)
-         |> assign(:github_connection, github_connection)}
+         |> assign(:github_connection, github_connection)
+         |> assign_agent_settings_form(workspace, current_user, is_owner)}
 
       {:error, _reason} ->
         {:noreply,
@@ -38,6 +39,18 @@ defmodule CitadelWeb.PreferencesLive.Workspace do
          |> put_flash(:error, "You do not have access to this workspace")
          |> redirect(to: ~p"/preferences")}
     end
+  end
+
+  defp assign_agent_settings_form(socket, _workspace, _user, false),
+    do: assign(socket, :agent_settings_form, nil)
+
+  defp assign_agent_settings_form(socket, workspace, user, true) do
+    form =
+      workspace
+      |> AshPhoenix.Form.for_update(:update, actor: user)
+      |> to_form()
+
+    assign(socket, :agent_settings_form, form)
   end
 
   defp load_github_connection(workspace_id, actor) do
@@ -196,6 +209,25 @@ defmodule CitadelWeb.PreferencesLive.Workspace do
 
       {:error, _error} ->
         {:noreply, put_flash(socket, :error, "Failed to revoke invitation")}
+    end
+  end
+
+  def handle_event("save-agent-settings", %{"form" => params}, socket) do
+    current_user = socket.assigns.current_user
+
+    case AshPhoenix.Form.submit(socket.assigns.agent_settings_form,
+           params: params,
+           action_opts: [actor: current_user]
+         ) do
+      {:ok, workspace} ->
+        {:noreply,
+         socket
+         |> assign(:workspace, workspace)
+         |> assign_agent_settings_form(workspace, current_user, socket.assigns.is_owner)
+         |> put_flash(:info, "Agent settings updated")}
+
+      {:error, form} ->
+        {:noreply, assign(socket, :agent_settings_form, form)}
     end
   end
 
@@ -372,6 +404,45 @@ defmodule CitadelWeb.PreferencesLive.Workspace do
                 Connect
               </.button>
               <span :if={!@is_owner} class="badge badge-ghost">Not connected</span>
+            <% end %>
+          </div>
+        </.card>
+
+        <.card class="bg-base-200 border-base-300">
+          <:title>Agent Settings</:title>
+
+          <div class="flex items-start justify-between gap-4 py-2">
+            <div class="flex-1 min-w-0">
+              <h4 class="font-medium">Max agent run duration</h4>
+              <p class="text-sm text-base-content/70 mt-1">
+                Hard wallclock cap on a single Claude Code run. Range 60&ndash;86400 seconds (default 14400 / 4 hours). Agents pick up changes on their next reconnect.
+              </p>
+            </div>
+
+            <%= if @is_owner do %>
+              <.form
+                for={@agent_settings_form}
+                id="agent-settings-form"
+                phx-submit="save-agent-settings"
+                class="flex items-end gap-2 shrink-0"
+              >
+                <div>
+                  <.input
+                    field={@agent_settings_form[:agent_max_run_seconds]}
+                    type="number"
+                    label="Seconds"
+                    min="60"
+                    max="86400"
+                    required
+                  />
+                </div>
+                <.button type="submit" variant="primary">Save</.button>
+              </.form>
+            <% else %>
+              <div class="shrink-0 text-right">
+                <div class="text-lg font-semibold">{@workspace.agent_max_run_seconds}s</div>
+                <div class="text-xs text-base-content/60">read-only</div>
+              </div>
             <% end %>
           </div>
         </.card>

--- a/lib/citadel_web/live/preferences_live/workspace.ex
+++ b/lib/citadel_web/live/preferences_live/workspace.ex
@@ -30,8 +30,7 @@ defmodule CitadelWeb.PreferencesLive.Workspace do
          |> assign(:memberships, memberships)
          |> assign(:invitations, invitations)
          |> assign(:is_owner, is_owner)
-         |> assign(:github_connection, github_connection)
-         |> assign_agent_settings_form(workspace, current_user, is_owner)}
+         |> assign(:github_connection, github_connection)}
 
       {:error, _reason} ->
         {:noreply,
@@ -39,18 +38,6 @@ defmodule CitadelWeb.PreferencesLive.Workspace do
          |> put_flash(:error, "You do not have access to this workspace")
          |> redirect(to: ~p"/preferences")}
     end
-  end
-
-  defp assign_agent_settings_form(socket, _workspace, _user, false),
-    do: assign(socket, :agent_settings_form, nil)
-
-  defp assign_agent_settings_form(socket, workspace, user, true) do
-    form =
-      workspace
-      |> AshPhoenix.Form.for_update(:update, actor: user)
-      |> to_form()
-
-    assign(socket, :agent_settings_form, form)
   end
 
   defp load_github_connection(workspace_id, actor) do
@@ -209,25 +196,6 @@ defmodule CitadelWeb.PreferencesLive.Workspace do
 
       {:error, _error} ->
         {:noreply, put_flash(socket, :error, "Failed to revoke invitation")}
-    end
-  end
-
-  def handle_event("save-agent-settings", %{"form" => params}, socket) do
-    current_user = socket.assigns.current_user
-
-    case AshPhoenix.Form.submit(socket.assigns.agent_settings_form,
-           params: params,
-           action_opts: [actor: current_user]
-         ) do
-      {:ok, workspace} ->
-        {:noreply,
-         socket
-         |> assign(:workspace, workspace)
-         |> assign_agent_settings_form(workspace, current_user, socket.assigns.is_owner)
-         |> put_flash(:info, "Agent settings updated")}
-
-      {:error, form} ->
-        {:noreply, assign(socket, :agent_settings_form, form)}
     end
   end
 
@@ -408,44 +376,13 @@ defmodule CitadelWeb.PreferencesLive.Workspace do
           </div>
         </.card>
 
-        <.card class="bg-base-200 border-base-300">
-          <:title>Agent Settings</:title>
-
-          <div class="flex items-start justify-between gap-4 py-2">
-            <div class="flex-1 min-w-0">
-              <h4 class="font-medium">Max agent run duration</h4>
-              <p class="text-sm text-base-content/70 mt-1">
-                Hard wallclock cap on a single Claude Code run. Range 60&ndash;86400 seconds (default 14400 / 4 hours). Agents pick up changes on their next reconnect.
-              </p>
-            </div>
-
-            <%= if @is_owner do %>
-              <.form
-                for={@agent_settings_form}
-                id="agent-settings-form"
-                phx-submit="save-agent-settings"
-                class="flex items-end gap-2 shrink-0"
-              >
-                <div>
-                  <.input
-                    field={@agent_settings_form[:agent_max_run_seconds]}
-                    type="number"
-                    label="Seconds"
-                    min="60"
-                    max="86400"
-                    required
-                  />
-                </div>
-                <.button type="submit" variant="primary">Save</.button>
-              </.form>
-            <% else %>
-              <div class="shrink-0 text-right">
-                <div class="text-lg font-semibold">{@workspace.agent_max_run_seconds}s</div>
-                <div class="text-xs text-base-content/60">read-only</div>
-              </div>
-            <% end %>
-          </div>
-        </.card>
+        <.live_component
+          module={CitadelWeb.PreferencesLive.Components.AgentSettingsCard}
+          id="agent-settings-card"
+          workspace_id={@workspace.id}
+          current_user={@current_user}
+          is_owner={@is_owner}
+        />
       </div>
 
       <.live_component

--- a/lib/citadel_web/live/preferences_live/workspace_form.ex
+++ b/lib/citadel_web/live/preferences_live/workspace_form.ex
@@ -144,20 +144,6 @@ defmodule CitadelWeb.PreferencesLive.WorkspaceForm do
               required
             />
 
-            <div :if={@workspace}>
-              <.input
-                field={@form[:agent_max_run_seconds]}
-                type="number"
-                label="Max agent run duration (seconds)"
-                min="60"
-                max="86400"
-                required
-              />
-              <p class="text-xs text-base-content/70 mt-1">
-                Hard wallclock cap on a single Claude Code run. Default 14400 (4 hours). Range: 60&ndash;86400. Agents pick up changes on their next reconnect.
-              </p>
-            </div>
-
             <div class="flex gap-2 justify-end">
               <.button type="button" phx-click="cancel" variant="ghost">
                 Cancel


### PR DESCRIPTION
## Summary

Move the **Max agent run duration** setting out of the workspace edit form and into its own **Agent Settings** card on the workspace details page (`/preferences/workspace/<id>`). Editing happens inline on the details page with an owner-only number input; non-owners see the current value read-only.

The workspace edit form (`/preferences/workspace/<id>/edit`) is back to just the workspace name field.

Follow-up to #219.

## Test plan

- [x] `mix ck` clean
- [x] 46 targeted LiveView tests pass (`workspace_test.exs` + `workspace_form_test.exs`)
- [ ] Manual: load workspace details page as owner, change the value, confirm flash and persisted update
- [ ] Manual: load as non-owner, confirm read-only display
- [ ] Manual: load the edit form, confirm only the workspace name field remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)