### PR TITLE
feat(task-details): redesign activity section as stream timeline

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -27,10 +27,27 @@
 
 :root {
   --citadel-color-border: oklch(20% 0 0);
+
+  /* Activity stream palette — used by TaskActivitySection.
+     Kept theme-stable: the timeline reads against the page bg, dot/pill
+     accents are tuned to be legible on both dark and light surfaces. */
+  --p-border: oklch(25% 0.005 250);
+  --p-amber: #f3c969;
+  --p-amber-soft: #f3c96922;
+  --p-teal: #2ee7a4;
+  --p-teal-soft: #2ee7a418;
+  --p-red: #f06a6a;
+  --p-red-soft: #f06a6a18;
+  --p-orange: #f49f5a;
+  --p-orange-soft: #f49f5a18;
+  --p-blue: #5cc1f0;
+  --p-blue-soft: #5cc1f018;
+  --p-violet: #b39df0;
 }
 
 [data-theme="citadel-light"] {
   --citadel-color-border: oklch(82% 0 0);
+  --p-border: oklch(82% 0 0);
 }
 
 @theme inline {
@@ -119,7 +136,16 @@
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 
 /* set root font family */
-html { font-family: "Exo 2", sans-serif; }
+html {
+  font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-sans: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+@theme {
+  --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
 
 /* Landing page gradient animation */
 @keyframes gradient-shift {
@@ -130,6 +156,23 @@ html { font-family: "Exo 2", sans-serif; }
 .animate-gradient {
   animation: gradient-shift 6s ease infinite;
 }
+
+/* Activity stream — pulsing in-progress rail dot */
+@keyframes stream-dot-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 0 4px var(--color-base-200),
+      0 0 0 5px var(--p-border),
+      0 0 0 5px rgba(92, 193, 240, 0.6);
+  }
+  50% {
+    box-shadow:
+      0 0 0 4px var(--color-base-200),
+      0 0 0 5px var(--p-border),
+      0 0 0 11px rgba(92, 193, 240, 0);
+  }
+}
+.stream-dot-pulse { animation: stream-dot-pulse 1.6s ease-in-out infinite; }
 
 
 /* Hide "Forgot your password?" link on the register form — it only makes sense on sign-in */

--- a/lib/citadel_web/components/layouts/root.html.heex
+++ b/lib/citadel_web/components/layouts/root.html.heex
@@ -52,7 +52,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Exo+2:ital,wght@0,100..900;1,100..900&family=SUSE+Mono:ital,wght@0,100..800;1,100..800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <script defer phx-track-static type="module" src={~p"/assets/js/app.js"}>

--- a/lib/citadel_web/live/components/task_activity_section.ex
+++ b/lib/citadel_web/live/components/task_activity_section.ex
@@ -4,9 +4,9 @@ defmodule CitadelWeb.Components.TaskActivitySection do
   use CitadelWeb, :live_component
 
   alias Citadel.Tasks
+  alias CitadelWeb.Components.Markdown
 
-  import CitadelWeb.Components.TaskComponents,
-    only: [user_avatar: 1, agent_run_status_classes: 1, agent_run_dot_class: 1]
+  import CitadelWeb.Components.TaskComponents, only: [user_avatar: 1]
 
   def update(%{broadcast: broadcast}, socket) do
     {:ok, handle_broadcast(broadcast, socket)}
@@ -25,7 +25,7 @@ defmodule CitadelWeb.Components.TaskActivitySection do
         socket
       else
         socket
-        |> stream(:activities, activities)
+        |> assign(:activities, sort_newest_first(activities))
         |> assign(:activities_loaded, true)
         |> assign(:form, to_form(%{"body" => ""}, as: :comment))
         |> assign(:request_changes, false)
@@ -51,7 +51,7 @@ defmodule CitadelWeb.Components.TaskActivitySection do
         actor: socket.assigns.current_user
       )
 
-    stream_insert(socket, :activities, activity)
+    upsert_activity(socket, activity)
   end
 
   defp handle_broadcast(
@@ -67,14 +67,25 @@ defmodule CitadelWeb.Components.TaskActivitySection do
         actor: socket.assigns.current_user
       )
 
-    stream_insert(socket, :activities, activity)
+    upsert_activity(socket, activity)
   end
 
   defp handle_broadcast(
          %Phoenix.Socket.Broadcast{event: "destroy_comment", payload: %{data: activity}},
          socket
        ) do
-    stream_delete(socket, :activities, activity)
+    activities = Enum.reject(socket.assigns.activities, &(&1.id == activity.id))
+    assign(socket, :activities, activities)
+  end
+
+  defp upsert_activity(socket, activity) do
+    activities =
+      socket.assigns.activities
+      |> Enum.reject(&(&1.id == activity.id))
+      |> List.insert_at(0, activity)
+      |> sort_newest_first()
+
+    assign(socket, :activities, activities)
   end
 
   defp reload_agent_run_activities(socket) do
@@ -85,10 +96,8 @@ defmodule CitadelWeb.Components.TaskActivitySection do
         load: [:user, :agent_run]
       )
 
-    agent_run_activities = Enum.filter(activities, &(&1.type == :agent_run))
-
-    Enum.reduce(agent_run_activities, socket, fn activity, acc ->
-      stream_insert(acc, :activities, activity)
+    Enum.reduce(activities, socket, fn activity, acc ->
+      if activity.type == :agent_run, do: upsert_activity(acc, activity), else: acc
     end)
   end
 
@@ -97,13 +106,7 @@ defmodule CitadelWeb.Components.TaskActivitySection do
   end
 
   def handle_event("toggle-reply", %{"id" => id}, socket) do
-    reply_to =
-      if socket.assigns.reply_to_activity_id == id do
-        nil
-      else
-        id
-      end
-
+    reply_to = if socket.assigns.reply_to_activity_id == id, do: nil, else: id
     {:noreply, assign(socket, :reply_to_activity_id, reply_to)}
   end
 
@@ -118,13 +121,14 @@ defmodule CitadelWeb.Components.TaskActivitySection do
       activity =
         cond do
           socket.assigns.reply_to_activity_id ->
-            params = %{
-              body: body,
-              task_id: socket.assigns.task.id,
-              parent_activity_id: socket.assigns.reply_to_activity_id
-            }
-
-            Tasks.create_question_response!(params, opts)
+            Tasks.create_question_response!(
+              %{
+                body: body,
+                task_id: socket.assigns.task.id,
+                parent_activity_id: socket.assigns.reply_to_activity_id
+              },
+              opts
+            )
 
           socket.assigns.request_changes ->
             Tasks.create_request_changes_comment!(
@@ -144,7 +148,7 @@ defmodule CitadelWeb.Components.TaskActivitySection do
 
       socket =
         socket
-        |> stream_insert(:activities, activity)
+        |> upsert_activity(activity)
         |> assign(:form, to_form(%{"body" => ""}, as: :comment))
         |> assign(:request_changes, false)
         |> assign(:reply_to_activity_id, nil)
@@ -165,7 +169,8 @@ defmodule CitadelWeb.Components.TaskActivitySection do
       tenant: socket.assigns.current_workspace.id
     )
 
-    {:noreply, stream_delete(socket, :activities, activity)}
+    activities = Enum.reject(socket.assigns.activities, &(&1.id == activity.id))
+    {:noreply, assign(socket, :activities, activities)}
   end
 
   def handle_event("request-cancel-agent-run", %{"run-id" => run_id}, socket) do
@@ -173,61 +178,110 @@ defmodule CitadelWeb.Components.TaskActivitySection do
     {:noreply, socket}
   end
 
-  def render(assigns) do
-    ~H"""
-    <div id={@id} class="py-4 border-t border-base-300 max-w-5xl">
-      <h2 class="text-sm font-semibold text-base-content/70 mb-4">Activity</h2>
+  defp sort_newest_first(activities) do
+    Enum.sort_by(activities, & &1.inserted_at, {:desc, DateTime})
+  end
 
-      <div id={"#{@id}-list"} phx-update="stream" class="space-y-3 mb-6">
-        <div id={"#{@id}-empty"} class="hidden only:block text-base-content/50 italic text-sm">
-          No activity yet
-        </div>
-        <div
-          :for={{dom_id, activity} <- @streams.activities}
-          id={dom_id}
-          class={[
-            "flex gap-2 group rounded-lg p-2 -ml-2",
-            activity.type == :change_request && "bg-warning/5 border-l-2 border-warning",
-            activity.type == :agent_run && "bg-base-200/50 border-l-2 border-info/40",
-            activity.type == :question && "bg-purple-500/5 border-l-2 border-purple-400",
-            activity.type == :question_response && "ml-8 bg-base-200/50 rounded-lg"
-          ]}
-        >
-          <div class="flex-shrink-0 pt-0.5">
-            <.activity_actor_avatar activity={activity} />
-          </div>
-          <div class="flex-1 min-w-0">
-            <%= if activity.type == :agent_run and not is_nil(activity.agent_run) do %>
-              <.agent_run_activity_content
+  defp group_by_day(activities) do
+    activities
+    |> Enum.group_by(&day_key(&1.inserted_at))
+    |> Enum.sort_by(fn {key, _} -> key end, :desc)
+  end
+
+  defp day_key(dt) do
+    dt
+    |> DateTime.to_date()
+    |> Date.to_iso8601()
+  end
+
+  defp day_label(dt) do
+    today = Date.utc_today()
+    date = DateTime.to_date(dt)
+
+    case Date.diff(today, date) do
+      0 -> "Today"
+      1 -> "Yesterday"
+      _ -> Calendar.strftime(date, "%b %-d")
+    end
+  end
+
+  def render(assigns) do
+    assigns =
+      assign(assigns, :grouped_activities, group_by_day(assigns.activities))
+
+    ~H"""
+    <div id={@id} class="py-6 border-t border-base-300 max-w-5xl">
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="font-mono text-xs font-semibold uppercase tracking-[0.08em] text-base-content/70">
+          Activity
+        </h2>
+        <span class="font-mono text-[11px] text-base-content/50">
+          {activity_count_label(@activities)}
+        </span>
+      </div>
+
+      <.stream_composer
+        id={@id}
+        form={@form}
+        request_changes={@request_changes}
+        reply_to_activity_id={@reply_to_activity_id}
+        current_user={@current_user}
+        myself={@myself}
+      />
+
+      <%= if @activities == [] do %>
+        <p class="text-base-content/50 italic text-sm pl-11 pt-2">No activity yet.</p>
+      <% else %>
+        <%= for {{_day_key, items}, gi} <- Enum.with_index(@grouped_activities) do %>
+          <% first_dt = hd(items).inserted_at %>
+          <div class={["pb-1", gi > 0 && "mt-4"]}>
+            <div class="flex items-center gap-3 ml-7 mb-3">
+              <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-base-content/50">
+                {day_label(first_dt)}
+              </span>
+              <span class="flex-1 h-px bg-base-300"></span>
+              <span class="font-mono text-[11px] text-base-content/40">{length(items)}</span>
+            </div>
+
+            <%= for {activity, idx} <- Enum.with_index(items) do %>
+              <.stream_item
                 activity={activity}
-                can_edit={@can_edit}
-                myself={@myself}
-              />
-            <% else %>
-              <.comment_activity_content
-                activity={activity}
+                first={gi == 0 and idx == 0}
+                last={gi == length(@grouped_activities) - 1 and idx == length(items) - 1}
                 current_user={@current_user}
+                can_edit={@can_edit}
                 myself={@myself}
               />
             <% end %>
           </div>
-        </div>
-      </div>
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
 
-      <.form
-        for={@form}
-        id={"#{@id}-form"}
-        phx-submit="submit-comment"
-        phx-target={@myself}
-        class="flex gap-2"
-      >
-        <div class="flex-shrink-0 pt-0.5">
-          <.user_avatar user={@current_user} />
-        </div>
-        <div class="flex-1">
+  attr :id, :string, required: true
+  attr :form, :any, required: true
+  attr :request_changes, :boolean, required: true
+  attr :reply_to_activity_id, :any, required: true
+  attr :current_user, :any, required: true
+  attr :myself, :any, required: true
+
+  defp stream_composer(assigns) do
+    ~H"""
+    <.form
+      for={@form}
+      id={"#{@id}-form"}
+      phx-submit="submit-comment"
+      phx-target={@myself}
+      class="mb-6 rounded-lg border border-base-300 bg-base-100/40 p-3"
+    >
+      <div class="flex gap-3 items-start">
+        <.user_avatar user={@current_user} size="w-6 h-6" />
+        <div class="flex-1 min-w-0">
           <div
             :if={@reply_to_activity_id}
-            class="flex items-center justify-between bg-purple-500/10 text-purple-400 text-xs px-3 py-1.5 rounded-t-lg border border-b-0 border-purple-400/20"
+            class="flex items-center justify-between bg-purple-500/10 text-purple-300 text-xs px-3 py-1.5 rounded-t-md border border-b-0 border-purple-400/20 -mt-1 -mx-1 mb-2"
           >
             <span>Replying to agent question</span>
             <button
@@ -235,34 +289,24 @@ defmodule CitadelWeb.Components.TaskActivitySection do
               phx-click="toggle-reply"
               phx-target={@myself}
               phx-value-id={@reply_to_activity_id}
-              class="hover:text-purple-300"
+              class="hover:text-purple-200"
             >
               <.icon name="hero-x-mark" class="size-3.5" />
             </button>
           </div>
           <textarea
             name={@form[:body].name}
-            value={@form[:body].value}
             rows="2"
-            placeholder={
-              cond do
-                @reply_to_activity_id -> "Type your reply to the agent's question..."
-                @request_changes -> "Describe what changes are needed..."
-                true -> "Add a comment..."
-              end
-            }
-            class={[
-              "textarea textarea-bordered w-full text-sm resize-none",
-              @reply_to_activity_id && "rounded-t-none"
-            ]}
+            placeholder={composer_placeholder(@reply_to_activity_id, @request_changes)}
+            class="w-full bg-transparent text-sm text-base-content placeholder:text-base-content/40 resize-none focus:outline-none leading-relaxed"
             id={"#{@id}-body"}
             phx-hook="CmdEnterSubmit"
-          />
-          <div class="flex items-center justify-between mt-2">
+          >{@form[:body].value}</textarea>
+
+          <div class="flex items-center justify-between mt-2 gap-3 flex-wrap">
             <label
               :if={!@reply_to_activity_id}
-              class="flex items-center gap-2 cursor-pointer select-none"
-              id={"#{@id}-request-changes-toggle"}
+              class="inline-flex items-center gap-2 cursor-pointer select-none font-sans text-xs text-base-content/60"
             >
               <input
                 type="checkbox"
@@ -272,235 +316,391 @@ defmodule CitadelWeb.Components.TaskActivitySection do
                 class="checkbox checkbox-warning checkbox-xs"
               />
               <span class={[
-                "text-xs",
-                if(@request_changes, do: "text-warning font-medium", else: "text-base-content/50")
+                @request_changes && "text-warning font-medium"
               ]}>
                 Request changes
               </span>
+              <span :if={@request_changes} class="text-base-content/40 text-[11px]">
+                — queues a new agent run
+              </span>
             </label>
-            <div :if={@reply_to_activity_id} />
+            <div :if={@reply_to_activity_id} class="flex-1" />
+
             <button
               type="submit"
               class={[
-                "btn btn-sm",
+                "btn btn-sm font-sans font-medium",
                 cond do
                   @reply_to_activity_id -> "btn-primary"
                   @request_changes -> "btn-warning"
-                  true -> "btn-primary"
+                  true -> "btn-neutral"
                 end
               ]}
             >
-              {cond do
-                @reply_to_activity_id -> "Reply"
-                @request_changes -> "Request Changes"
-                true -> "Comment"
-              end}
+              {composer_submit_label(@reply_to_activity_id, @request_changes)}
             </button>
           </div>
         </div>
-      </.form>
-    </div>
+      </div>
+    </.form>
     """
   end
 
+  defp composer_placeholder(reply_id, request_changes) do
+    cond do
+      reply_id -> "Type your reply to the agent's question…"
+      request_changes -> "Describe what changes are needed…"
+      true -> "Leave a comment… (markdown supported)"
+    end
+  end
+
+  defp composer_submit_label(reply_id, request_changes) do
+    cond do
+      reply_id -> "Reply"
+      request_changes -> "Comment & queue run"
+      true -> "Comment"
+    end
+  end
+
   attr :activity, :map, required: true
+  attr :first, :boolean, required: true
+  attr :last, :boolean, required: true
   attr :current_user, :any, required: true
-  attr :myself, :any, required: true
-
-  defp comment_activity_content(assigns) do
-    ~H"""
-    <div class="flex items-center gap-2">
-      <span class="text-sm font-medium text-base-content">
-        <.activity_actor_name activity={@activity} />
-      </span>
-      <span
-        :if={@activity.type == :change_request}
-        class="inline-flex items-center gap-1 text-xs font-medium text-warning bg-warning/10 px-1.5 py-0.5 rounded"
-      >
-        <.icon name="hero-arrow-path" class="size-3" /> Changes Requested
-      </span>
-      <span
-        :if={@activity.type == :question}
-        class="inline-flex items-center gap-1 text-xs font-medium text-purple-400 bg-purple-500/10 px-1.5 py-0.5 rounded"
-      >
-        <.icon name="hero-question-mark-circle" class="size-3" /> Agent Question
-      </span>
-      <span
-        :if={@activity.type == :question_response}
-        class="inline-flex items-center gap-1 text-xs font-medium text-base-content/50 bg-base-200 px-1.5 py-0.5 rounded"
-      >
-        In Reply
-      </span>
-      <span class="text-xs text-base-content/40">
-        {relative_time(@activity.inserted_at)}
-      </span>
-      <button
-        :if={@activity.user_id == @current_user.id}
-        phx-click="delete-comment"
-        phx-target={@myself}
-        phx-value-id={@activity.id}
-        class="text-xs text-base-content/30 hover:text-error opacity-0 group-hover:opacity-100 transition-opacity"
-        data-confirm="Delete this comment?"
-      >
-        <.icon name="hero-trash" class="size-3" />
-      </button>
-      <button
-        :if={@activity.type == :question}
-        phx-click="toggle-reply"
-        phx-target={@myself}
-        phx-value-id={@activity.id}
-        class="text-xs text-purple-400 hover:text-purple-300 opacity-0 group-hover:opacity-100 transition-opacity"
-      >
-        <.icon name="hero-chat-bubble-left" class="size-3" /> Reply
-      </button>
-    </div>
-    <p class="text-sm text-base-content/80 mt-1">
-      {@activity.body}
-    </p>
-    """
-  end
-
-  attr :activity, :map, required: true
   attr :can_edit, :boolean, required: true
   attr :myself, :any, required: true
 
-  defp agent_run_activity_content(assigns) do
-    assigns = assign(assigns, :run, assigns.activity.agent_run)
+  defp stream_item(assigns) do
+    %{label: pill_label, color: pill_color, soft: pill_soft, pulse: pulse?} =
+      status_meta(assigns.activity)
+
+    assigns =
+      assigns
+      |> assign(:pill_label, pill_label)
+      |> assign(:pill_color, pill_color)
+      |> assign(:pill_soft, pill_soft)
+      |> assign(:pulse?, pulse?)
+      |> assign(:run, assigns.activity.agent_run)
 
     ~H"""
-    <div class="flex items-center justify-between mb-2">
-      <div class="flex items-center gap-2">
-        <span class="text-sm font-medium text-base-content">
-          <.activity_actor_name activity={@activity} />
-        </span>
-        <span class={[
-          "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium",
-          agent_run_status_classes(@run.status)
-        ]}>
-          <span class={["size-1.5 rounded-full", agent_run_dot_class(@run.status)]} />
-          {@run.status}
-        </span>
-        <span :if={@run.error_message} class="text-xs text-error">
-          {@run.error_message}
-        </span>
+    <div class="flex items-start group">
+      <div class="relative w-7 flex-none self-stretch">
+        <span class="absolute" style={rail_line_style(@first, @last)} />
+        <span
+          class={["absolute rounded-full", @pulse? && "stream-dot-pulse"]}
+          style={rail_dot_style(@pill_color)}
+        />
+      </div>
+
+      <div class="flex-1 min-w-0 pb-5 pl-1">
+        <div class="flex items-center gap-3 flex-wrap">
+          <.activity_avatar activity={@activity} />
+          <span class="font-mono text-[13px] font-medium text-base-content">
+            {actor_short_name(@activity)}
+          </span>
+          <.status_pill label={@pill_label} color={@pill_color} soft={@pill_soft} />
+
+          <span class="flex-1"></span>
+
+          <span
+            :if={
+              @activity.type == :agent_run and not is_nil(@run) and not is_nil(@run.started_at) and
+                not is_nil(@run.completed_at)
+            }
+            class="font-mono text-[11px] text-base-content/50"
+          >
+            {format_duration(@run.started_at, @run.completed_at)}
+          </span>
+          <span
+            class="font-mono text-[11px] text-base-content/50"
+            title={Calendar.strftime(@activity.inserted_at, "%Y-%m-%d %H:%M:%S UTC")}
+          >
+            {relative_time(@activity.inserted_at)}
+          </span>
+        </div>
+
+        <.activity_body
+          activity={@activity}
+          run={@run}
+          current_user={@current_user}
+          can_edit={@can_edit}
+          myself={@myself}
+        />
+      </div>
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :color, :string, required: true
+  attr :soft, :string, required: true
+
+  defp status_pill(assigns) do
+    ~H"""
+    <span
+      :if={@label}
+      class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full font-mono text-[11px] font-medium"
+      style={"background: #{@soft}; color: #{@color};"}
+    >
+      <span
+        class="size-1.5 rounded-full flex-none"
+        style={"background: #{@color};"}
+      />
+      {@label}
+    </span>
+    """
+  end
+
+  attr :activity, :map, required: true
+  attr :run, :any, required: true
+  attr :current_user, :any, required: true
+  attr :can_edit, :boolean, required: true
+  attr :myself, :any, required: true
+
+  defp activity_body(%{activity: %{type: :agent_run}} = assigns) do
+    ~H"""
+    <%= if @run do %>
+      <p
+        :if={@run.error_message}
+        class="mt-2 text-[13.5px] leading-relaxed text-base-content/70 max-w-2xl"
+      >
+        <span :if={@run.status == :failed} class="text-error font-mono mr-1.5">✗</span>
+        {@run.error_message}
+      </p>
+
+      <p
+        :if={is_nil(@run.error_message) and @run.status == :running and not is_nil(@run.session_id)}
+        class="mt-2 text-[13.5px] leading-relaxed text-base-content/60 max-w-2xl font-mono text-xs"
+      >
+        session {String.slice(@run.session_id, 0..7)}…
+      </p>
+
+      <details
+        :if={is_list(@run.commits) and @run.commits != []}
+        class="mt-3 max-w-2xl group/commits"
+      >
+        <summary class="font-mono text-[11px] text-info hover:text-info/80 cursor-pointer select-none inline-flex items-center gap-1.5 list-none">
+          <.icon name="hero-chevron-right" class="size-3" /> Commits ({length(@run.commits)})
+        </summary>
+        <div class="mt-2 ml-1 pl-3 border-l border-base-300 flex flex-col gap-1">
+          <div
+            :for={commit <- @run.commits}
+            class="flex items-center gap-2 font-mono text-[12px] py-0.5"
+          >
+            <span class="text-purple-300 min-w-[60px]">
+              {String.slice(commit["sha"] || "", 0..6)}
+            </span>
+            <span class="text-base-content/70 truncate">{commit["message"]}</span>
+          </div>
+        </div>
+      </details>
+
+      <details
+        :if={@run.test_output && @run.test_output != ""}
+        class="mt-2 max-w-2xl group/output"
+      >
+        <summary class="font-mono text-[11px] text-info hover:text-info/80 cursor-pointer select-none inline-flex items-center gap-1.5 list-none">
+          <.icon name="hero-chevron-right" class="size-3" /> Test Output
+        </summary>
+        <pre class="mt-2 p-3 bg-black border border-base-300 rounded-md font-mono text-[11.5px] leading-relaxed text-base-content/70 whitespace-pre-wrap max-h-96 overflow-auto"><code>{@run.test_output}</code></pre>
+      </details>
+
+      <div class="mt-2 flex items-center gap-4 flex-wrap">
         <.link
           navigate={~p"/agent-runs/#{@run.id}"}
-          class="btn btn-xs btn-ghost text-info hover:bg-info/10"
+          class="font-mono text-[11px] text-info hover:text-info/80 inline-flex items-center gap-1"
         >
-          <.icon name="hero-eye" class="size-3.5" />
+          <.icon name="hero-arrow-top-right-on-square" class="size-3" />
           {if @run.status == :running, do: "Watch", else: "View"}
         </.link>
+
         <button
           :if={@can_edit and @run.status in [:pending, :running]}
           phx-click="request-cancel-agent-run"
           phx-target={@myself}
           phx-value-run-id={@run.id}
-          class="btn btn-xs btn-ghost text-error hover:bg-error/10"
+          class="font-mono text-[11px] text-base-content/50 hover:text-error inline-flex items-center gap-1"
         >
-          <.icon name="hero-x-mark" class="size-3.5" /> Cancel
+          <.icon name="hero-x-mark" class="size-3" /> Cancel
         </button>
       </div>
-      <div class="text-xs text-base-content/50 flex gap-3">
-        <span class="text-xs text-base-content/40">
-          {relative_time(@activity.inserted_at)}
-        </span>
-        <span :if={@run.started_at}>
-          Started: {Calendar.strftime(@run.started_at, "%b %d %H:%M:%S")}
-        </span>
-        <span :if={@run.completed_at}>
-          Completed: {Calendar.strftime(@run.completed_at, "%b %d %H:%M:%S")}
-        </span>
-      </div>
+    <% else %>
+      <p class="mt-2 text-[13.5px] text-base-content/50 italic">Agent run no longer available.</p>
+    <% end %>
+    """
+  end
+
+  defp activity_body(%{activity: %{type: type}} = assigns)
+       when type in [:comment, :change_request, :question, :question_response] do
+    ~H"""
+    <div class="mt-2 max-w-2xl prose prose-sm prose-invert">
+      {Markdown.to_markdown(@activity.body || "")}
     </div>
 
-    <details :if={@run.commits != nil and @run.commits != []} class="group/details">
-      <summary class="text-xs font-medium text-base-content/60 cursor-pointer hover:text-base-content/80 select-none">
-        Commits ({length(@run.commits)})
-      </summary>
-      <ul class="mt-2 space-y-1">
-        <li :for={commit <- @run.commits} class="flex items-start gap-2 text-xs">
-          <code class="px-1.5 py-0.5 bg-base-300/50 rounded font-mono text-base-content/70 shrink-0">
-            {String.slice(commit["sha"], 0..6)}
-          </code>
-          <span class="text-base-content/80">{commit["message"]}</span>
-        </li>
-      </ul>
-    </details>
-
-    <details :if={@run.test_output && @run.test_output != ""} class="group/details mt-2">
-      <summary class="text-xs font-medium text-base-content/60 cursor-pointer hover:text-base-content/80 select-none">
-        Test Output
-      </summary>
-      <pre class="mt-2 p-3 bg-base-300/50 rounded text-xs overflow-x-auto max-h-96 overflow-y-auto"><code>{@run.test_output}</code></pre>
-    </details>
-    """
-  end
-
-  attr :activity, :map, required: true
-
-  defp activity_actor_avatar(%{activity: %{actor_type: :user, user: user}} = assigns)
-       when not is_nil(user) do
-    assigns = assign(assigns, :user, user)
-
-    ~H"""
-    <.user_avatar user={@user} />
-    """
-  end
-
-  defp activity_actor_avatar(%{activity: %{actor_type: :system}} = assigns) do
-    ~H"""
-    <div class="avatar avatar-placeholder">
-      <div class="w-6 h-6 rounded-full bg-base-300 flex items-center justify-center text-xs">
-        <.icon name="hero-cog-6-tooth" class="size-3.5 text-base-content/60" />
-      </div>
-    </div>
-    """
-  end
-
-  defp activity_actor_avatar(%{activity: %{actor_type: :ai}} = assigns) do
-    ~H"""
-    <div class="avatar avatar-placeholder">
-      <div class="w-6 h-6 rounded-full bg-base-300 flex items-center justify-center text-xs">
-        <.icon name="hero-cpu-chip" class="size-3.5 text-base-content/60" />
-      </div>
-    </div>
-    """
-  end
-
-  defp activity_actor_avatar(assigns) do
-    ~H"""
-    <div class="avatar avatar-placeholder">
-      <div class="w-6 h-6 rounded-full bg-base-300 flex items-center justify-center text-xs">
-        ?
-      </div>
+    <div class="mt-1 flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity">
+      <button
+        :if={@activity.type == :question}
+        phx-click="toggle-reply"
+        phx-target={@myself}
+        phx-value-id={@activity.id}
+        class="font-mono text-[11px] text-purple-300 hover:text-purple-200 inline-flex items-center gap-1"
+      >
+        <.icon name="hero-chat-bubble-left" class="size-3" /> reply
+      </button>
+      <button
+        :if={@activity.user_id == @current_user.id}
+        phx-click="delete-comment"
+        phx-target={@myself}
+        phx-value-id={@activity.id}
+        data-confirm="Delete this comment?"
+        class="font-mono text-[11px] text-base-content/40 hover:text-error inline-flex items-center gap-1"
+      >
+        <.icon name="hero-trash" class="size-3" /> delete
+      </button>
     </div>
     """
   end
 
   attr :activity, :map, required: true
 
-  defp activity_actor_name(%{activity: %{actor_type: :user, user: user}} = assigns)
+  defp activity_avatar(%{activity: %{actor_type: :user, user: user}} = assigns)
        when not is_nil(user) do
     assigns = assign(assigns, :user, user)
 
     ~H"""
-    {to_string(@user.email)}
+    <.user_avatar user={@user} size="w-6 h-6" />
     """
   end
 
-  defp activity_actor_name(%{activity: %{actor_display_name: name}} = assigns)
-       when not is_nil(name) do
-    assigns = assign(assigns, :name, name)
-
+  defp activity_avatar(%{activity: %{actor_type: type}} = assigns) when type in [:ai, :system] do
     ~H"""
-    {@name}
+    <div
+      class="w-6 h-6 rounded-[6px] border border-base-content/20 bg-base-100 flex items-center justify-center text-base-content/70"
+      title="Agent"
+    >
+      <.icon name="hero-cpu-chip" class="size-3.5" />
+    </div>
     """
   end
 
-  defp activity_actor_name(assigns) do
+  defp activity_avatar(assigns) do
     ~H"""
-    Unknown
+    <div class="w-6 h-6 rounded-full bg-base-300 flex items-center justify-center text-[10px] text-base-content/60">
+      ?
+    </div>
     """
+  end
+
+  defp actor_short_name(%{actor_type: :user, user: %{email: email}}) when not is_nil(email) do
+    email
+    |> to_string()
+    |> String.split("@")
+    |> List.first()
+  end
+
+  defp actor_short_name(%{actor_display_name: name}) when not is_nil(name), do: name
+  defp actor_short_name(%{actor_type: :ai}), do: "agent"
+  defp actor_short_name(%{actor_type: :system}), do: "system"
+  defp actor_short_name(_), do: "unknown"
+
+  defp activity_count_label(activities) do
+    total = length(activities)
+    running = Enum.count(activities, &agent_running?/1)
+
+    cond do
+      total == 0 -> "0 events"
+      running > 0 -> "#{total} events · #{running} active"
+      true -> "#{total} events"
+    end
+  end
+
+  defp agent_running?(%{type: :agent_run, agent_run: %{status: status}})
+       when status in [:running, :pending, :input_requested],
+       do: true
+
+  defp agent_running?(_), do: false
+
+  defp status_meta(%{type: :agent_run, agent_run: %{status: :running}}),
+    do: %{label: "running", color: "var(--p-blue)", soft: "var(--p-blue-soft)", pulse: true}
+
+  defp status_meta(%{type: :agent_run, agent_run: %{status: :pending}}),
+    do: %{label: "pending", color: "var(--p-blue)", soft: "var(--p-blue-soft)", pulse: false}
+
+  defp status_meta(%{type: :agent_run, agent_run: %{status: :completed}}),
+    do: %{label: "completed", color: "var(--p-teal)", soft: "var(--p-teal-soft)", pulse: false}
+
+  defp status_meta(%{type: :agent_run, agent_run: %{status: :failed}}),
+    do: %{label: "failed", color: "var(--p-red)", soft: "var(--p-red-soft)", pulse: false}
+
+  defp status_meta(%{type: :agent_run, agent_run: %{status: :cancelled}}),
+    do: %{
+      label: "cancelled",
+      color: "var(--p-orange)",
+      soft: "var(--p-orange-soft)",
+      pulse: false
+    }
+
+  defp status_meta(%{type: :agent_run, agent_run: %{status: :input_requested}}),
+    do: %{
+      label: "awaiting input",
+      color: "var(--p-violet)",
+      soft: "rgba(179, 157, 240, 0.15)",
+      pulse: true
+    }
+
+  defp status_meta(%{type: :agent_run}),
+    do: %{label: "agent run", color: "var(--p-blue)", soft: "var(--p-blue-soft)", pulse: false}
+
+  defp status_meta(%{type: :change_request}),
+    do: %{
+      label: "changes requested",
+      color: "var(--p-amber)",
+      soft: "var(--p-amber-soft)",
+      pulse: false
+    }
+
+  defp status_meta(%{type: :question}),
+    do: %{
+      label: "question",
+      color: "var(--p-violet)",
+      soft: "rgba(179, 157, 240, 0.15)",
+      pulse: false
+    }
+
+  defp status_meta(%{type: :question_response}),
+    do: %{label: "reply", color: "var(--p-teal)", soft: "var(--p-teal-soft)", pulse: false}
+
+  defp status_meta(_),
+    do: %{label: nil, color: "var(--color-base-content)", soft: "transparent", pulse: false}
+
+  defp format_duration(%DateTime{} = started, %DateTime{} = completed) do
+    seconds = DateTime.diff(completed, started, :second)
+
+    cond do
+      seconds < 60 -> "#{seconds}s"
+      seconds < 3600 -> "#{div(seconds, 60)}m #{rem(seconds, 60)}s"
+      true -> "#{div(seconds, 3600)}h #{rem(div(seconds, 60), 60)}m"
+    end
+  end
+
+  defp format_duration(_, _), do: ""
+
+  defp rail_line_style(first, last) do
+    top = if first, do: "12px", else: "0"
+
+    base =
+      "left: 13px; top: #{top}; width: 2px;"
+
+    if last do
+      base <>
+        " height: 16px; background: linear-gradient(180deg, var(--color-base-300), transparent);"
+    else
+      base <> " bottom: 0; background: var(--color-base-300);"
+    end
+  end
+
+  defp rail_dot_style(color) do
+    "top: 10px; left: 9px; width: 10px; height: 10px; background: #{color}; " <>
+      "box-shadow: 0 0 0 4px var(--color-base-200), 0 0 0 5px var(--color-base-300);"
   end
 
   defp relative_time(datetime) do
@@ -509,10 +709,10 @@ defmodule CitadelWeb.Components.TaskActivitySection do
 
     cond do
       diff < 60 -> "just now"
-      diff < 3600 -> "#{div(diff, 60)} min ago"
-      diff < 86_400 -> "#{div(diff, 3600)} hours ago"
-      diff < 604_800 -> "#{div(diff, 86_400)} days ago"
-      true -> Calendar.strftime(datetime, "%b %d, %Y")
+      diff < 3600 -> "#{div(diff, 60)}m"
+      diff < 86_400 -> "#{div(diff, 3600)}h"
+      diff < 604_800 -> "#{div(diff, 86_400)}d"
+      true -> Calendar.strftime(datetime, "%b %-d")
     end
   end
 end

--- a/lib/citadel_web/live/components/task_dependencies.ex
+++ b/lib/citadel_web/live/components/task_dependencies.ex
@@ -25,12 +25,12 @@ defmodule CitadelWeb.Components.TaskDependencies do
 
   def render(assigns) do
     ~H"""
-    <div class="py-4 border-t border-base-300">
+    <div class="py-6 border-t border-base-300">
       <%= if @dependencies_loaded or @dependents_loaded do %>
-        <h2 class="text-sm font-semibold text-base-content/70 mb-3">
+        <h2 class="font-mono text-xs font-semibold uppercase tracking-[0.08em] text-base-content/70 mb-3">
           Blocked by
           <%= if @task.blocked? do %>
-            <span class="badge badge-warning badge-sm ml-2">Blocked</span>
+            <span class="badge badge-warning badge-sm ml-2 normal-case tracking-normal">Blocked</span>
           <% end %>
         </h2>
 
@@ -81,7 +81,9 @@ defmodule CitadelWeb.Components.TaskDependencies do
 
           <%= if @dependents_loaded and not Enum.empty?(@task.dependents) do %>
             <div>
-              <h2 class="text-sm font-semibold text-base-content/70 mb-3">Blocks</h2>
+              <h2 class="font-mono text-xs font-semibold uppercase tracking-[0.08em] text-base-content/70 mb-3">
+                Blocks
+              </h2>
               <div class="space-y-2">
                 <%= for dependent <- @task.dependents do %>
                   <div class="flex items-center gap-2 p-2 bg-base-100 rounded-lg border border-base-300">

--- a/lib/citadel_web/live/task_live/show.ex
+++ b/lib/citadel_web/live/task_live/show.ex
@@ -769,7 +769,7 @@ defmodule CitadelWeb.TaskLive.Show do
           phx-update="ignore"
           data-content={@task.description || ""}
           data-readonly={to_string(not @can_edit)}
-          class="milkdown-container prose max-w-none"
+          class="milkdown-container prose prose-sm max-w-none"
         />
       </div>
 

--- a/lib/citadel_web/live/task_live/show.ex
+++ b/lib/citadel_web/live/task_live/show.ex
@@ -707,13 +707,13 @@ defmodule CitadelWeb.TaskLive.Show do
 
   defp task_content(assigns) do
     ~H"""
-    <div class="breadcrumbs text-sm mb-4">
+    <div class="breadcrumbs font-mono text-xs mb-4 text-base-content/50">
       <ul>
         <li><.link navigate={~p"/dashboard"}>Tasks</.link></li>
         <li :for={ancestor <- @task.ancestors}>
           <.link navigate={~p"/tasks/#{ancestor.human_id}"}>{ancestor.human_id}</.link>
         </li>
-        <li><span>{@task.human_id}</span></li>
+        <li><span class="text-base-content/70">{@task.human_id}</span></li>
       </ul>
     </div>
 
@@ -739,10 +739,10 @@ defmodule CitadelWeb.TaskLive.Show do
             phx-blur="save-title"
             phx-keydown="save-title"
             phx-key="Enter"
-            class="input input-ghost text-2xl font-bold flex-1 p-0 h-auto min-h-0 focus:outline-none focus:bg-base-300/50 rounded"
+            class="input input-ghost font-mono text-2xl font-semibold tracking-tight flex-1 p-0 h-auto min-h-0 focus:outline-none focus:bg-base-300/50 rounded"
           />
         <% else %>
-          <h1 class="card-title text-2xl">{@task.title}</h1>
+          <h1 class="card-title font-mono text-2xl font-semibold tracking-tight">{@task.title}</h1>
         <% end %>
       </div>
       <div class="flex gap-2">
@@ -760,7 +760,9 @@ defmodule CitadelWeb.TaskLive.Show do
 
     <div class="grid grid-cols-[1fr_20rem] gap-4">
       <div class="py-4">
-        <h2 class="text-sm font-semibold text-base-content/70 mb-2">Description</h2>
+        <h2 class="font-mono text-xs font-semibold uppercase tracking-[0.08em] text-base-content/70 mb-3">
+          Description
+        </h2>
         <div
           id={"description-editor-#{@task.id}"}
           phx-hook="MilkdownEditor"
@@ -774,7 +776,7 @@ defmodule CitadelWeb.TaskLive.Show do
       <div class="border-l border-base-300 p-4">
         <div class="sticky top-0 space-y-5">
           <div class="flex items-center justify-between gap-4">
-            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+            <label class="font-mono text-[10.5px] font-medium text-base-content/60 uppercase tracking-[0.08em] whitespace-nowrap">
               Priority
             </label>
             <%= if @can_edit do %>
@@ -792,7 +794,7 @@ defmodule CitadelWeb.TaskLive.Show do
           </div>
 
           <div class="flex items-center justify-between gap-4">
-            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+            <label class="font-mono text-[10.5px] font-medium text-base-content/60 uppercase tracking-[0.08em] whitespace-nowrap">
               Assignees
             </label>
             <%= if @can_edit do %>
@@ -818,7 +820,7 @@ defmodule CitadelWeb.TaskLive.Show do
           </div>
 
           <div class="flex items-center justify-between gap-4">
-            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+            <label class="font-mono text-[10.5px] font-medium text-base-content/60 uppercase tracking-[0.08em] whitespace-nowrap">
               Due Date
             </label>
             <%= if @can_edit do %>
@@ -849,7 +851,7 @@ defmodule CitadelWeb.TaskLive.Show do
           </div>
 
           <div class="flex items-center justify-between gap-4">
-            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+            <label class="font-mono text-[10.5px] font-medium text-base-content/60 uppercase tracking-[0.08em] whitespace-nowrap">
               Project
             </label>
             <%= if @task.project do %>
@@ -863,7 +865,7 @@ defmodule CitadelWeb.TaskLive.Show do
             :if={@task.execution_status != :none}
             class="flex items-center justify-between gap-4"
           >
-            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+            <label class="font-mono text-[10.5px] font-medium text-base-content/60 uppercase tracking-[0.08em] whitespace-nowrap">
               Execution
             </label>
             <span class={[
@@ -879,7 +881,7 @@ defmodule CitadelWeb.TaskLive.Show do
           </div>
 
           <div class="flex items-center justify-between gap-4">
-            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+            <label class="font-mono text-[10.5px] font-medium text-base-content/60 uppercase tracking-[0.08em] whitespace-nowrap">
               Agent
             </label>
             <%= if @can_edit do %>
@@ -911,7 +913,7 @@ defmodule CitadelWeb.TaskLive.Show do
 
           <% {pr_label, pr_text} = forge_pr_label(@task.forge_pr) %>
           <div class="flex items-center justify-between gap-4">
-            <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide whitespace-nowrap">
+            <label class="font-mono text-[10.5px] font-medium text-base-content/60 uppercase tracking-[0.08em] whitespace-nowrap">
               {pr_label}
             </label>
             <%= if @task.forge_pr do %>
@@ -941,9 +943,9 @@ defmodule CitadelWeb.TaskLive.Show do
       current_workspace={@current_workspace}
     />
 
-    <div class="py-4 border-t border-base-300">
+    <div class="py-6 border-t border-base-300">
       <div class="flex items-center justify-between mb-3 mr-6">
-        <h2 class="text-sm font-semibold text-base-content/70">
+        <h2 class="font-mono text-xs font-semibold uppercase tracking-[0.08em] text-base-content/70">
           Sub-tasks{if @sub_tasks.ok?, do: " (#{length(@sub_tasks.result)})"}
         </h2>
         <.button :if={@can_edit} class="btn btn-xs btn-secondary" phx-click="new-sub-task">

--- a/priv/repo/dev_seed_task_activity.exs
+++ b/priv/repo/dev_seed_task_activity.exs
@@ -1,0 +1,225 @@
+# Dev-only seed for the task-details activity timeline redesign.
+#
+# Idempotent — re-running drops + recreates the seed task so the activity
+# timeline is the same shape every time (useful for visual checks).
+#
+# Run with:
+#   mix run priv/repo/dev_seed_task_activity.exs
+#
+# Sign in afterwards with:
+#   email: dev@citadel.test
+#   password: DevPassword123!
+
+require Ash.Query
+
+alias Citadel.Accounts
+alias Citadel.Tasks
+
+dev_email = "dev@citadel.test"
+dev_password = "DevPassword123!"
+task_title = "Github Actions CI"
+
+# --- Task states (matches priv/repo/seeds.exs so this is safe in any env) ----
+
+Tasks.create_task_state!(%{name: "Todo", order: 1}, upsert?: true, upsert_identity: :unique_name)
+
+Tasks.create_task_state!(%{name: "In Progress", order: 2},
+  upsert?: true,
+  upsert_identity: :unique_name
+)
+
+Tasks.create_task_state!(%{name: "Complete", order: 3},
+  upsert?: true,
+  upsert_identity: :unique_name
+)
+
+in_progress_state =
+  Tasks.list_task_states!(authorize?: false)
+  |> Enum.find(&(&1.name == "In Progress"))
+
+# --- Dev user (find by email or register; register_with_password also creates
+#      the user's Personal organization + Personal workspace via after_action). -
+
+user =
+  case Accounts.User
+       |> Ash.Query.for_read(:get_by_email, %{email: dev_email}, authorize?: false)
+       |> Ash.read_one(authorize?: false) do
+    {:ok, %Accounts.User{} = u} ->
+      u
+
+    _ ->
+      strategy = AshAuthentication.Info.strategy!(Accounts.User, :password)
+
+      {:ok, u} =
+        AshAuthentication.Strategy.action(strategy, :register, %{
+          "email" => dev_email,
+          "password" => dev_password,
+          "password_confirmation" => dev_password
+        })
+
+      u
+  end
+
+[workspace | _] = Accounts.list_workspaces!(actor: user, load: [:owner])
+tenant = workspace.id
+
+# --- Reset any previous seed task so re-runs are deterministic. ---
+
+Tasks.list_tasks!(actor: user, tenant: tenant)
+|> Enum.filter(&(&1.title == task_title))
+|> Enum.each(&Tasks.destroy_task!(&1, actor: user, tenant: tenant))
+
+# --- Seed task. ---
+
+task =
+  Tasks.create_task!(
+    %{
+      title: task_title,
+      description: """
+      We need a proper CI pipeline for this project. At minimum we should run
+      formatting, linting, security, and test checks. Before you begin, do
+      some research on best practices for CI pipelines for elixir
+      applications. Try to parallelize and cache whenever possible to keep
+      execution times to a minimum.
+      """,
+      task_state_id: in_progress_state.id,
+      priority: :high,
+      agent_eligible: true
+    },
+    actor: user,
+    tenant: tenant
+  )
+
+# MaybeEnqueueAgentWork autocreates a :new_task work item on task create when
+# agent_eligible is true. The agent_work_items table has a unique partial
+# index ("one active per task") that would later collide with the
+# request-changes work item the seed creates further down. Cancel any
+# autocreated work items so the rest of the seed is free to run.
+Citadel.Tasks.AgentWorkItem
+|> Ash.Query.filter(task_id == ^task.id and status in [:pending, :claimed])
+|> Ash.read!(authorize?: false, tenant: tenant)
+|> Enum.each(&Tasks.cancel_agent_work_item!(&1, authorize?: false, tenant: tenant))
+
+opts = [actor: user, tenant: tenant]
+
+# Helper: create a run, then update it to its final shape.
+update_run = fn run, attrs ->
+  {:ok, updated} = Tasks.update_agent_run(run, attrs, actor: user, tenant: tenant)
+  updated
+end
+
+# 1) Two stalled / failed retries in a row.
+run1 = Tasks.create_agent_run!(%{task_id: task.id, status: :pending}, opts)
+
+_ =
+  update_run.(run1, %{
+    status: :failed,
+    started_at: DateTime.utc_now() |> DateTime.add(-96 * 3600, :second),
+    completed_at: DateTime.utc_now() |> DateTime.add(-95 * 3600, :second),
+    error_message:
+      "Claude Code process stalled after 600s of inactivity. Partial output (425,140 bytes) captured before kill.",
+    test_output: "mix format --check-formatted\n** stalled — no stdout for 600s, killed."
+  })
+
+run2 = Tasks.create_agent_run!(%{task_id: task.id, status: :pending}, opts)
+
+_ =
+  update_run.(run2, %{
+    status: :failed,
+    started_at: DateTime.utc_now() |> DateTime.add(-94 * 3600, :second),
+    completed_at: DateTime.utc_now() |> DateTime.add(-93 * 3600, :second),
+    error_message:
+      "Claude Code process stalled after 600s of inactivity. Partial output (141,260 bytes) captured before kill.",
+    test_output: "  warning: unused variable `pipeline_opts`\n** stalled — no stdout for 600s, killed."
+  })
+
+# 2) A cancelled run (reaped).
+run3 = Tasks.create_agent_run!(%{task_id: task.id, status: :pending}, opts)
+
+_ =
+  update_run.(run3, %{
+    status: :cancelled,
+    started_at: DateTime.utc_now() |> DateTime.add(-36 * 3600, :second),
+    completed_at: DateTime.utc_now() |> DateTime.add(-35 * 3600, :second),
+    error_message: "Reaped: running run had no connected agent."
+  })
+
+# 3) A completed run with commits + test output.
+run4 = Tasks.create_agent_run!(%{task_id: task.id, status: :pending}, opts)
+
+_ =
+  update_run.(run4, %{
+    status: :completed,
+    started_at: DateTime.utc_now() |> DateTime.add(-12 * 3600, :second),
+    completed_at:
+      DateTime.utc_now() |> DateTime.add(-11 * 3600 - 42 * 60, :second),
+    session_id: "sess_8a4f21c9b002dabcdef0",
+    commits: [
+      %{"sha" => "8a4f21cabcdef", "message" => "feat(ci): parallel test matrix with cached deps"},
+      %{"sha" => "c9b002dabcdef", "message" => "feat(ci): add credo + sobelow security checks"}
+    ],
+    test_output: """
+    Compiling 87 files (.ex)
+    Generated citadel app
+
+    Finished in 7.4 seconds (5.2s async, 2.2s sync)
+    412 tests, 0 failures
+    """
+  })
+
+# 4) A user comment that requests changes (queues a new agent run).
+_change_request =
+  Tasks.create_request_changes_comment!(
+    %{
+      body: """
+      Address the **credo issues** that are causing the pipeline to fail so this can be merged.
+
+      Specifically the warnings flagged in:
+
+      - `lib/citadel/billing/invoice.ex` — unused alias
+      - `lib/citadel/jobs/reaper.ex` — function complexity > 10
+      - `lib/citadel_web/router.ex` — pipe chain depth
+
+      Once those are clean, re-run `mix credo --strict` and confirm exit `0` before pushing.
+      """,
+      task_id: task.id
+    },
+    actor: user,
+    tenant: tenant
+  )
+
+# 5) A plain follow-up comment (no markdown — exercises the simpler row).
+_comment =
+  Tasks.create_comment!(
+    %{body: "Thanks — I'll spin up another run once those are clean.", task_id: task.id},
+    actor: user,
+    tenant: tenant
+  )
+
+# 6) An in-progress run currently running (pulse on the rail).
+running_run = Tasks.create_agent_run!(%{task_id: task.id, status: :pending}, opts)
+
+running_run =
+  update_run.(running_run, %{
+    status: :running,
+    started_at: DateTime.utc_now() |> DateTime.add(-90, :second),
+    session_id: "sess_resolving_credo_warnings_42a"
+  })
+
+IO.puts("""
+
+Seed complete.
+
+  user:     #{dev_email}
+  password: #{dev_password}
+  workspace: #{workspace.name} (#{workspace.id})
+  task:     #{task.human_id} — #{task.title}
+  url:      http://localhost:4100/tasks/#{task.human_id}
+
+  Activities created:
+    - 2 failed retries (#{run1.id}, #{run2.id})
+    - 1 cancelled (#{run3.id})
+    - 1 completed with commits (#{run4.id})
+    - 1 change-request comment + 1 plain comment
+    - 1 in-progress run (#{running_run.id})
+""")


### PR DESCRIPTION
## Summary

- Rewrite the task-details activity section as a day-grouped vertical rail timeline. Status dots on the rail (pulsing for in-progress), status pills, agent vs human avatars, relative timestamps, inline `<details>` for commits + test output, markdown-rendered comments. Composer pinned at top with a single submit whose label flips between `Comment` and `Comment & queue run`.
- Swap `Exo 2` + `SUSE Mono` for **IBM Plex Sans** + **JetBrains Mono**; wire both through Tailwind `@theme` so `font-sans` / `font-mono` map to them. Apply mono uppercase tracking to the page title, breadcrumbs, all section headers, and metadata-rail labels.
- Add an activity-stream colour palette (`--p-*`) and a `stream-dot-pulse` keyframe in `app.css`. The timeline pulls colours from these so the pills stay legible against both `citadel-dark` and `citadel-light`.
- Add `priv/repo/dev_seed_task_activity.exs` — idempotent dev seed that creates `dev@citadel.test` / `DevPassword123!` plus a task with the full activity menagerie (2 failed retries, 1 cancelled, 1 completed with commits, 1 change-request comment, 1 plain comment, 1 running run) for visual verification.

## Notable internals

- Activity list switched from a Phoenix stream to a plain list assign so day-grouped headers can render. Same PubSub upsert/destroy semantics, routed through \`upsert_activity/2\`.
- Commits and Test Output use native \`<details>\` elements so the existing \`assert html =~ \"Commits (N)\"\` / \`assert html =~ \"Test Output\"\` tests keep passing.
- Reply-to-agent-question composer mode is preserved (purple banner appears when \`reply_to_activity_id\` is set); the simplified mockup composer didn't have it but it's still used in the question / question_response flow.

## Things to call out / lost behaviour

- **Coloured row containers** for \`change_request\` / \`agent_run\` / \`question\` are gone; row identity now lives in the rail dot colour + pill. (Explicit ask from the design chat: \"flatten so every row reads as the same kind of timeline entry.\")
- **No per-run natural-language summary** like the mockup shows (\"Implemented parallel test matrix, added credo + sobelow security checks\"). \`AgentRun\` doesn't store an equivalent — completed/running runs render with just the avatar/name/pill/duration and the collapsible commits/test_output. Would need a new \`summary\` attribute on \`AgentRun\` (or a derived value from events) to fully match.
- **Merge-retries / density / order / timestamp-style tweaks** from the design's Tweaks panel are not wired up — shipped just the final \"by day, newest first, relative, regular density\" combination.
- **Action labels stayed Title Case** (\`Watch\`, \`View\`, \`Cancel\`, \`Test Output\`, \`Commits (N)\`) to match existing test assertions rather than the mockup's lowercase. Easy to flip if the lowercase vocabulary is preferred.

## Test plan

- [x] \`MIX_ENV=test mix test test/citadel_web/live/task_live/\` — 77 tests green
- [x] \`MIX_ENV=test mix test test/citadel_web/live/task_live/show_activity_test.exs\` — 14 tests
- [x] \`MIX_ENV=test mix test test/citadel_web/live/task_live/show_agent_run_activity_test.exs\` — 12 tests
- [x] \`mix compile --warnings-as-errors\`
- [x] Visual: signed in via \`/sign-in\`, navigated to seeded task, confirmed timeline + fonts + pulsing dot + commits/test-output collapses + change-request markdown render

## Followups (not in this PR)

- Persist a one-line summary on \`AgentRun\` so the timeline matches the design's run rows
- Decide whether to expose any of the design's Tweaks knobs (density, order, timestamp style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)